### PR TITLE
Dashboard APIs DynamoDB Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Visualize your AWS IoT data with the IoT Application.
    yarn install
    ```
 1. Update the [apps/client/aws-resources.js](apps/client/aws-resources.js) file with AWS resources created from step 1
+1. [Download](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html) and run the DynamoDB local at port `:8000`
 1. Start development server:
    ```sh
    yarn dev

--- a/apps/core/jest-dynamodb-config.js
+++ b/apps/core/jest-dynamodb-config.js
@@ -1,0 +1,30 @@
+module.exports = {
+  port: 8001,
+  tables: [
+    {
+      TableName: 'dashboard-api-e2e-test',
+      KeySchema: [
+        { AttributeName: 'id', KeyType: 'HASH' },
+        { AttributeName: 'resourceType', KeyType: 'RANGE' }
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'id', AttributeType: 'S' },
+        { AttributeName: 'resourceType', AttributeType: 'S' },
+        { AttributeName: 'lastUpdateDate', AttributeType: 'S' },
+      ],
+      BillingMode: 'PAY_PER_REQUEST',
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: 'resourceTypeIndex',
+          KeySchema: [
+            { AttributeName: 'resourceType', KeyType: 'HASH' },
+            // { AttributeName: 'lastUpdateDate', KeyType: 'RANGE' }
+          ],
+          Projection: {
+            ProjectionType: 'ALL',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/apps/core/jest.config.ts
+++ b/apps/core/jest.config.ts
@@ -2,8 +2,12 @@ import type { Config } from 'jest';
 
 import baseConfig from 'jest-config/base';
 
+const jestDynamodb = require('@shelf/jest-dynamodb/jest-preset');
+
 const config: Config = {
   ...baseConfig,
+  //https://jestjs.io/docs/dynamodb
+  ...jestDynamodb,
   collectCoverageFrom: [
     '**/src/**/*.{js,ts}',
     '!./src/main.ts',
@@ -16,6 +20,11 @@ const config: Config = {
   transform: {
     '^.*\\.ts$': 'ts-jest',
   },
+  moduleNameMapper: {
+    // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
+    "^uuid$": "uuid",
+  },
+  
 };
 
 export default config;

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -15,8 +15,11 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.259.0",
+    "@aws-sdk/lib-dynamodb": "^3.259.0",
     "@fastify/static": "^6.6.1",
     "@nestjs/common": "^9.0.0",
+    "@nestjs/config": "^2.3.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-fastify": "^9.2.1",

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -34,6 +34,7 @@
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",
+    "@shelf/jest-dynamodb": "^3.4.1",
     "eslint-config-custom-server": "*",
     "jest-config": "*",
     "run-script-webpack-plugin": "^0.1.1",

--- a/apps/core/src/config/database.config.ts
+++ b/apps/core/src/config/database.config.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('database', () => ({
+  endpoint: process.env.DATABASE_ENDPOINT || 'http://localhost:8000',
+  tableName: process.env.DATABASE_TABLE_NAME || 'ApiResourceTable',
+}));

--- a/apps/core/src/config/database.config.ts
+++ b/apps/core/src/config/database.config.ts
@@ -1,6 +1,0 @@
-import { registerAs } from '@nestjs/config';
-
-export default registerAs('database', () => ({
-  endpoint: process.env.DATABASE_ENDPOINT || 'http://localhost:8000',
-  tableName: process.env.DATABASE_TABLE_NAME || 'ApiResourceTable',
-}));

--- a/apps/core/src/dashboards/config/database.config.ts
+++ b/apps/core/src/dashboards/config/database.config.ts
@@ -1,0 +1,7 @@
+import { registerAs } from '@nestjs/config';
+
+export const databaseConfig = registerAs('database', () => ({
+  // TODO: consume endpoint and tableName from environment variables
+  endpoint: 'http://localhost:8000',
+  tableName: 'ApiResourceTable',
+}));

--- a/apps/core/src/dashboards/controllers/create.controller.ts
+++ b/apps/core/src/dashboards/controllers/create.controller.ts
@@ -13,7 +13,11 @@ import { CreateDashboardDto } from '../dto/create-dashboard.dto';
  * POST /dashboards HTTP/1.1
  *
  * {
- *   "name": "Wind Farm 4"
+ *   "name": "Wind Farm 4",
+ *   "description": "Wind Farm 4 Description",
+ *   "definition": {
+ *     "widgets": []
+ *   }
  * }
  * ```
  *
@@ -25,6 +29,7 @@ import { CreateDashboardDto } from '../dto/create-dashboard.dto';
  * {
  *   "id": {dashboardId},
  *   "name": "Wind Farm 4",
+ *   "description": "Wind Farm 4 Description",
  *   "definition": {
  *     "widgets": []
  *   }
@@ -38,6 +43,6 @@ export class CreateDashboardController {
 
   @Post()
   public create(@Body() createDashboardDto: CreateDashboardDto) {
-    return this.dashboardsService.create(createDashboardDto.name);
+    return this.dashboardsService.create(createDashboardDto);
   }
 }

--- a/apps/core/src/dashboards/controllers/delete.controller.ts
+++ b/apps/core/src/dashboards/controllers/delete.controller.ts
@@ -32,10 +32,10 @@ export class DeleteDashboardController {
 
   @HttpCode(204)
   @Delete(':id')
-  public delete(@Param() params: DeleteDashboardParams) {
-    const dashboard = this.dashboardsService.delete(params.id);
+  public async delete(@Param() params: DeleteDashboardParams) {
+    const deleted = await this.dashboardsService.delete(params.id);
 
-    if (dashboard === undefined) {
+    if (!deleted) {
       throw new NotFoundException();
     }
   }

--- a/apps/core/src/dashboards/controllers/list.controller.ts
+++ b/apps/core/src/dashboards/controllers/list.controller.ts
@@ -20,16 +20,12 @@ import { DashboardsService } from '../dashboards.service';
  * [{
  *   "id": {dashboardId},
  *   "name": "Wind Farm 1",
- *   "definition": {
- *     "widgets": []
- *   }
+ *   "description": "Wind Farm 1 Description"
  * },
  * {
  *   "id": {dashboardId},
  *   "name": "Wind Farm 2",
- *   "definition": {
- *     "widgets": []
- *   }
+ *   "description": "Wind Farm 2 Description"
  * }]
  * ```
  */

--- a/apps/core/src/dashboards/controllers/read.controller.ts
+++ b/apps/core/src/dashboards/controllers/read.controller.ts
@@ -21,6 +21,7 @@ import { ReadDashboardParams } from '../params/read-dashboard.params';
  * {
  *   "id": {dashboardId},
  *   "name": "Wind Farm 4",
+ *   "description": "Wind Farm 4 Description",
  *   "definition": {
  *     "widgets": []
  *   }
@@ -33,8 +34,8 @@ export class ReadDashboardController {
   constructor(private readonly dashboardsService: DashboardsService) {}
 
   @Get(':id')
-  public read(@Param() params: ReadDashboardParams) {
-    const dashboard = this.dashboardsService.read(params.id);
+  public async read(@Param() params: ReadDashboardParams) {
+    const dashboard = await this.dashboardsService.read(params.id);
 
     if (dashboard === undefined) {
       throw new NotFoundException();

--- a/apps/core/src/dashboards/controllers/update.controller.ts
+++ b/apps/core/src/dashboards/controllers/update.controller.ts
@@ -21,6 +21,7 @@ import { UpdateDashboardParams } from '../params/update-dashboard.params';
  *
  * {
  *   "name": "Wind Farm 4",
+ *   "description": "Wind Farm 4 Description",
  *   "definition": {
  *     "widgets": []
  *   }
@@ -35,6 +36,7 @@ import { UpdateDashboardParams } from '../params/update-dashboard.params';
  * {
  *   "id": {dashboardId},
  *   "name": "Wind Farm 4",
+ *   "description": "Wind Farm 4 Description",
  *   "definition": {
  *     "widgets": []
  *   }
@@ -47,11 +49,11 @@ export class UpdateDashboardController {
   constructor(private readonly dashboardsService: DashboardsService) {}
 
   @Put(':id')
-  public update(
+  public async update(
     @Param() params: UpdateDashboardParams,
     @Body() updateDashboardDto: UpdateDashboardDto,
   ) {
-    const dashboard = this.dashboardsService.update({
+    const dashboard = await this.dashboardsService.update({
       ...updateDashboardDto,
       ...params,
     });

--- a/apps/core/src/dashboards/dashboard.constants.ts
+++ b/apps/core/src/dashboards/dashboard.constants.ts
@@ -1,0 +1,12 @@
+export const RESOURCE_TYPES = {
+  DASHBOARD_DATA: 'DashboardData',
+  DASHBOARD_DEFINITION: 'DashboardDefinition',
+};
+
+export const DATABASE_GSI = {
+  RESOURCE_TYPE: 'resourceTypeIndex',
+};
+
+export const MESSAGES = {
+  ITEM_NOT_FOUND_ERROR: 'Missing dashboard data or definition',
+};

--- a/apps/core/src/dashboards/dashboards.module.ts
+++ b/apps/core/src/dashboards/dashboards.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
+import { Module, ModuleMetadata } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import databaseConfig from 'src/config/database.config';
+import { databaseConfig } from './config/database.config';
 
 import { CreateDashboardController } from './controllers/create.controller';
 import { DeleteDashboardController } from './controllers/delete.controller';
@@ -9,13 +9,8 @@ import { ReadDashboardController } from './controllers/read.controller';
 import { UpdateDashboardController } from './controllers/update.controller';
 import { DashboardsService } from './dashboards.service';
 
-/** Core Dashboards Module */
-@Module({
-  imports: [
-    ConfigModule.forRoot({
-      load: [databaseConfig],
-    }),
-  ],
+export const dashboardsModuleMetadata: ModuleMetadata = {
+  imports: [ConfigModule.forFeature(databaseConfig)],
   controllers: [
     CreateDashboardController,
     DeleteDashboardController,
@@ -24,5 +19,8 @@ import { DashboardsService } from './dashboards.service';
     UpdateDashboardController,
   ],
   providers: [DashboardsService],
-})
+};
+
+/** Core Dashboards Module */
+@Module(dashboardsModuleMetadata)
 export class DashboardsModule {}

--- a/apps/core/src/dashboards/dashboards.module.ts
+++ b/apps/core/src/dashboards/dashboards.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import databaseConfig from 'src/config/database.config';
 
 import { CreateDashboardController } from './controllers/create.controller';
 import { DeleteDashboardController } from './controllers/delete.controller';
@@ -9,6 +11,11 @@ import { DashboardsService } from './dashboards.service';
 
 /** Core Dashboards Module */
 @Module({
+  imports: [
+    ConfigModule.forRoot({
+      load: [databaseConfig],
+    }),
+  ],
   controllers: [
     CreateDashboardController,
     DeleteDashboardController,

--- a/apps/core/src/dashboards/dashboards.service.ts
+++ b/apps/core/src/dashboards/dashboards.service.ts
@@ -1,125 +1,433 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { DynamoDBClient, QueryCommandOutput } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  TransactGetCommand,
+  TransactWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  TransactionCanceledException,
+  BatchStatementErrorCodeEnum,
+} from '@aws-sdk/client-dynamodb';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { plainToClass } from 'class-transformer';
 import { nanoid } from 'nanoid';
-
+import { DATABASE_GSI, MESSAGES, RESOURCE_TYPES } from './dashboard.constants';
+import { CreateDashboardDto } from './dto/create-dashboard.dto';
+import { DashboardSummary } from './entities/dashboard-summary.entity';
 import { Dashboard } from './entities/dashboard.entity';
+import { ConfigType } from '@nestjs/config';
+import databaseConfig from 'src/config/database.config';
 
 @Injectable()
 export class DashboardsService {
   private readonly logger = new Logger(DashboardsService.name);
-  private dashboards: Dashboard[] = [];
+  private dbDocClient: DynamoDBDocumentClient;
+  private tableName: string;
 
-  public create(name: Dashboard['name']) {
+  constructor(@Inject(databaseConfig.KEY) dbConfig: ConfigType<typeof databaseConfig>,) {
+    this.dbDocClient = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ endpoint: dbConfig.endpoint }),
+      {
+        marshallOptions: {
+          convertClassInstanceToMap: true,
+        },
+      },
+    );
+
+    this.tableName = dbConfig.tableName;
+  }
+
+  public async create(createDashboardDto: CreateDashboardDto) {
     this.logger.log('Creating dashboard...');
 
     try {
-      const dashboard = this.createDashboard(name);
-
-      this.dashboards = [...this.dashboards, dashboard];
+      const dashboard = await this.createDashboard(createDashboardDto);
 
       this.logger.log(`Created dashboard ${dashboard.id}`);
       this.logger.log(dashboard);
 
       return dashboard;
-    } catch {
+    } catch (error) {
       this.logger.warn('Failed to create dashboard');
+      this.logger.warn(error);
 
-      return undefined;
+      throw error;
     }
   }
 
-  public list() {
+  public async list(): Promise<DashboardSummary[]> {
     this.logger.log('Finding all dashboards...');
 
     try {
+      const dashboards = this.listDashboards();
       this.logger.log('Found all dashboards');
-      this.logger.log(this.dashboards);
+      this.logger.log(dashboards);
 
-      return this.dashboards;
-    } catch {
+      return dashboards;
+    } catch (error) {
       this.logger.warn('Failed to find all dashboards');
+      this.logger.warn(error);
 
-      return undefined;
+      throw error;
     }
   }
 
-  public read(id: Dashboard['id']) {
+  public async read(id: Dashboard['id']): Promise<Dashboard | undefined> {
     this.logger.log(`Finding dashboard ${id}...`);
 
     try {
-      const dashboard = this.find(id);
+      const dashboard = await this.find(id);
 
-      this.logger.log(`Found dashboard ${id}`);
-      this.logger.log(dashboard);
+      if (dashboard === undefined) {
+        this.logger.warn(`Not found dashboard ${id}`);
+      } else {
+        this.logger.log(`Found dashboard ${id}`);
+        this.logger.log(dashboard);
+      }
 
-      return this.find(id);
-    } catch {
+      return dashboard;
+    } catch (error) {
       this.logger.warn(`Failed to find dashboard ${id}`);
+      this.logger.warn(error);
 
-      return undefined;
+      throw error;
     }
   }
 
-  public update(dashboard: Dashboard) {
+  public async update(dashboard: Dashboard) {
     this.logger.log(`Updating dashboard ${dashboard.id}...`);
 
     try {
-      this.dashboards = this.withUpdatedDashboard(dashboard);
-      const updatedDashboard = this.find(dashboard.id);
+      const updatedDashboard = await this.updateDashboard(dashboard);
+      const { id } = dashboard;
 
-      this.logger.log(`Updated dashboard ${dashboard.id}`);
-      this.logger.log(dashboard);
+      if (dashboard === undefined) {
+        this.logger.log(`Updated dashboard ${id}`);
+        this.logger.log(updatedDashboard);
+      } else {
+        this.logger.warn(`Update failure, not found dashboard ${id}`);
+      }
 
       return updatedDashboard;
-    } catch {
+    } catch (error) {
       this.logger.warn(`Failed to update dashboard ${dashboard.id}`);
+      this.logger.warn(error);
 
-      return undefined;
+      throw error;
     }
   }
 
-  public delete(id: Dashboard['id']) {
+  public async delete(id: Dashboard['id']): Promise<boolean> {
     this.logger.log(`Deleting dashboard ${id}...`);
 
     try {
-      const dashboard = this.find(id);
+      const deleted = await this.deleteDashboard(id);
 
-      if (dashboard === undefined) {
-        throw new Error();
+      if (deleted) {
+        this.logger.log(`Deleted dashboard ${id}`);
+      } else {
+        this.logger.warn(`Deletion failure, not found dashboard ${id}`);
       }
 
-      this.dashboards = this.withoutDashboard(dashboard);
-
-      this.logger.log(`Deleted dashboard ${id}`);
-
-      return dashboard;
-    } catch {
+      return deleted;
+    } catch (error) {
       this.logger.warn(`Failed to delete dashboard ${id}`);
+      this.logger.warn(error);
 
-      return undefined;
+      throw error;
     }
   }
 
-  private createDashboard(name: Dashboard['name']): Dashboard {
+  private async createDashboard({
+    name,
+    definition,
+    description,
+  }: CreateDashboardDto): Promise<Dashboard> {
     const id = nanoid(12);
+    const creationDateObj = new Date();
+    const creationDate = creationDateObj.toISOString();
+    const lastUpdateDate = creationDate;
+
+    await this.dbDocClient.send(
+      new TransactWriteCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: this.tableName,
+              Item: {
+                id,
+                resourceType: RESOURCE_TYPES.DASHBOARD_DEFINITION,
+                definition,
+                creationDate,
+                lastUpdateDate,
+              },
+              ConditionExpression: 'attribute_not_exists(id)',
+            },
+          },
+          {
+            Put: {
+              TableName: this.tableName,
+              Item: {
+                id,
+                resourceType: RESOURCE_TYPES.DASHBOARD_DATA,
+                name,
+                description,
+                creationDate,
+                lastUpdateDate,
+              },
+              ConditionExpression: 'attribute_not_exists(id)',
+            },
+          },
+        ],
+      }),
+    );
+
+    return {
+      name,
+      definition,
+      description,
+      id,
+    };
+  }
+
+  private async updateDashboard({
+    id,
+    name,
+    description,
+    definition,
+  }: Dashboard) {
+    const creationDateObj = new Date();
+    const creationDate = creationDateObj.toISOString();
+    const lastUpdateDate = creationDate;
+
+    try {
+      await this.dbDocClient.send(
+        new TransactWriteCommand({
+          TransactItems: [
+            {
+              Update: {
+                TableName: this.tableName,
+                Key: {
+                  id,
+                  resourceType: RESOURCE_TYPES.DASHBOARD_DEFINITION,
+                },
+                // Capture the DDB reserved words, see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+                UpdateExpression:
+                  'set #definition = :definition, lastUpdateDate = :lastUpdateDate',
+                ExpressionAttributeValues: {
+                  ':id': id,
+                  ':resourceType': RESOURCE_TYPES.DASHBOARD_DEFINITION,
+                  ':definition': definition,
+                  ':lastUpdateDate': lastUpdateDate,
+                },
+                ExpressionAttributeNames: {
+                  '#definition': 'definition',
+                },
+                ConditionExpression:
+                  '(id = :id) and (resourceType = :resourceType)',
+              },
+            },
+            {
+              Update: {
+                TableName: this.tableName,
+                Key: {
+                  id,
+                  resourceType: RESOURCE_TYPES.DASHBOARD_DATA,
+                },
+                // Capture the DDB reserved words, see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+                UpdateExpression:
+                  'set #name = :name, #description = :description, lastUpdateDate = :lastUpdateDate',
+                ExpressionAttributeValues: {
+                  ':id': id,
+                  ':resourceType': RESOURCE_TYPES.DASHBOARD_DATA,
+                  ':name': name,
+                  ':description': description,
+                  ':lastUpdateDate': lastUpdateDate,
+                },
+                ExpressionAttributeNames: {
+                  '#name': 'name',
+                  '#description': 'description',
+                },
+                ConditionExpression:
+                  '(id = :id) and (resourceType = :resourceType)',
+              },
+            },
+          ],
+        }),
+      );
+    } catch (error) {
+      if (error instanceof TransactionCanceledException) {
+        if (this.conditionalCheckFailed(error)) {
+          return undefined;
+        }
+      }
+
+      throw error;
+    }
 
     return {
       id,
       name,
-      definition: {
-        widgets: [],
-      },
+      definition,
+      description,
     };
   }
 
-  private withUpdatedDashboard(dashboard: Dashboard) {
-    return this.dashboards.map((d) => (d.id !== dashboard.id ? d : dashboard));
+  /**
+   * Delete a dashboard from the database.
+   * @param id the id of the dashboard
+   * @returns true if the given dashboard is deleted; false if the dashboard id is not found.
+   */
+  private async deleteDashboard(id: Dashboard['id']): Promise<boolean> {
+    try {
+      await this.dbDocClient.send(
+        new TransactWriteCommand({
+          TransactItems: [
+            {
+              Delete: {
+                TableName: this.tableName,
+                Key: {
+                  id,
+                  resourceType: RESOURCE_TYPES.DASHBOARD_DATA,
+                },
+                ExpressionAttributeValues: {
+                  ':id': id,
+                  ':resourceType': RESOURCE_TYPES.DASHBOARD_DATA,
+                },
+                ConditionExpression:
+                  '(id = :id) and (resourceType = :resourceType)',
+              },
+            },
+            {
+              Delete: {
+                TableName: this.tableName,
+                Key: {
+                  id,
+                  resourceType: RESOURCE_TYPES.DASHBOARD_DEFINITION,
+                },
+                ExpressionAttributeValues: {
+                  ':id': id,
+                  ':resourceType': RESOURCE_TYPES.DASHBOARD_DEFINITION,
+                },
+                ConditionExpression:
+                  '(id = :id) and (resourceType = :resourceType)',
+              },
+            },
+          ],
+        }),
+      );
+
+      return true;
+    } catch (error) {
+      if (error instanceof TransactionCanceledException) {
+        if (this.conditionalCheckFailed(error)) {
+          return false;
+        }
+      }
+
+      throw error;
+    }
   }
 
-  private withoutDashboard(dashboard: Dashboard) {
-    return this.dashboards.filter((d) => d.id !== dashboard.id);
+  private async find(id: Dashboard['id']): Promise<Dashboard | undefined> {
+    const { Responses } = await this.dbDocClient.send(
+      new TransactGetCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: this.tableName,
+              Key: {
+                id,
+                resourceType: RESOURCE_TYPES.DASHBOARD_DATA,
+              },
+            },
+          },
+          {
+            Get: {
+              TableName: this.tableName,
+              Key: { id, resourceType: RESOURCE_TYPES.DASHBOARD_DEFINITION },
+            },
+          },
+        ],
+      }),
+    );
+
+    if (Responses === undefined) {
+      return undefined;
+    }
+
+    const dashboardData = Responses[0]?.Item;
+    const dashboardDefinition = Responses[1]?.Item;
+
+    if (dashboardData === undefined && dashboardDefinition === undefined) {
+      return undefined;
+    }
+
+    if (dashboardData === undefined || dashboardDefinition === undefined) {
+      this.logger.error(
+        `${dashboardData ? 'dashboard definition' : 'dashboard data'} missing`,
+      );
+      throw new Error(MESSAGES.ITEM_NOT_FOUND_ERROR);
+    }
+
+    return plainToClass(Dashboard, {
+      id,
+      description: dashboardData.description as string,
+      name: dashboardData.name as string,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      definition: dashboardDefinition.definition,
+    });
   }
 
-  private find(id: Dashboard['id']) {
-    return this.dashboards.find((d) => d.id === id);
+  private async listDashboards(): Promise<DashboardSummary[]> {
+    let dashboards: DashboardSummary[] = [];
+    let lastEvaluatedKey: Record<string, unknown> | undefined = undefined;
+
+    do {
+      const queryOutput: QueryCommandOutput = await this.dbDocClient.send(
+        new QueryCommand({
+          TableName: this.tableName,
+          KeyConditionExpression: 'resourceType = :resourceType',
+          ExpressionAttributeValues: {
+            ':resourceType': RESOURCE_TYPES.DASHBOARD_DATA,
+          },
+          IndexName: DATABASE_GSI.RESOURCE_TYPE,
+          ...(lastEvaluatedKey === undefined ? {} :{
+            ExclusiveStartKey: lastEvaluatedKey,
+          })
+        }),
+      );
+
+      lastEvaluatedKey = queryOutput.LastEvaluatedKey;
+
+      if (queryOutput.Items) {
+        dashboards = dashboards.concat(
+          queryOutput.Items.map((item) => {
+            const id = item.id;
+            const name = item.name;
+            const description = item.description;
+  
+            return plainToClass(DashboardSummary, {
+              id,
+              name,
+              description,
+            });
+          }),
+        );
+      }
+
+      this.logger.log(
+        `lastEvaluatedKey ${JSON.stringify(lastEvaluatedKey, null, 2)}`,
+      );
+    } while (lastEvaluatedKey);
+
+    return dashboards;
+  }
+
+  private conditionalCheckFailed(error: TransactionCanceledException): boolean {
+    return error?.CancellationReasons !== undefined && error.CancellationReasons.some((reason) => {
+      return reason.Code === BatchStatementErrorCodeEnum.ConditionalCheckFailed;
+    });
   }
 }

--- a/apps/core/src/dashboards/entities/dashboard-summary.entity.ts
+++ b/apps/core/src/dashboards/entities/dashboard-summary.entity.ts
@@ -3,4 +3,6 @@ import { OmitType } from '@nestjs/swagger';
 import { Dashboard } from '../entities/dashboard.entity';
 
 /** POST /dashboards HTTP/1.1 request body */
-export class CreateDashboardDto extends OmitType(Dashboard, ['id'] as const) {}
+export class DashboardSummary extends OmitType(Dashboard, [
+  'definition',
+] as const) {}

--- a/apps/core/src/dashboards/entities/dashboard.entity.ts
+++ b/apps/core/src/dashboards/entities/dashboard.entity.ts
@@ -28,7 +28,7 @@ export class Dashboard {
    * @example "Wind Farm 4 Description"
    */
   @IsString()
-  @Length(1, 1024)
+  @Length(0, 1024)
   public readonly description: DashboardDescription;
 
   @IsObject()

--- a/apps/core/src/dashboards/entities/dashboard.entity.ts
+++ b/apps/core/src/dashboards/entities/dashboard.entity.ts
@@ -6,8 +6,6 @@ import { DashboardDefinition } from './dashboard-definition.entity';
 export type DashboardId = string;
 export type DashboardName = string;
 export type DashboardDescription = string;
-export type DashboardCreationDate = Date;
-export type DashboardLastUpdateDate = Date;
 
 export class Dashboard {
   /**

--- a/apps/core/src/dashboards/entities/dashboard.entity.ts
+++ b/apps/core/src/dashboards/entities/dashboard.entity.ts
@@ -5,6 +5,9 @@ import { DashboardDefinition } from './dashboard-definition.entity';
 
 export type DashboardId = string;
 export type DashboardName = string;
+export type DashboardDescription = string;
+export type DashboardCreationDate = Date;
+export type DashboardLastUpdateDate = Date;
 
 export class Dashboard {
   /**
@@ -20,6 +23,13 @@ export class Dashboard {
   @IsString()
   @Length(1, 100)
   public readonly name: DashboardName;
+
+  /**
+   * @example "Wind Farm 4 Description"
+   */
+  @IsString()
+  @Length(1, 1024)
+  public readonly description: DashboardDescription;
 
   @IsObject()
   @ValidateNested()

--- a/aws-resources-cfn-template.yaml
+++ b/aws-resources-cfn-template.yaml
@@ -29,9 +29,7 @@ Resources:
     Properties:
       IdentityPoolId: !Ref IdentityPool
       Roles:
-        authenticated: !GetAtt 
-          - AuthenticatedRole
-          - Arn
+        authenticated: !GetAtt AuthenticatedRole.Arn
       RoleMappings:
         cognito-user-pool:
           IdentityProvider: !Sub >-
@@ -58,8 +56,8 @@ Resources:
               'ForAnyValue:StringLike':
                 'cognito-identity.amazonaws.com:amr': authenticated
       Policies:
-        # TODO: tighten the admin-group-policy policy permissions to require actions only
-        - PolicyName: admin-group-policy
+        # TODO: tighten the authenticated-role-policy policy permissions to require actions only
+        - PolicyName: authenticated-role-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -69,3 +67,31 @@ Resources:
                   - 'iotsitewise:*'
                 Resource:
                   - '*'
+  
+  ApiResourceTable:
+    Type: 'AWS::DynamoDB::Table'
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+        - AttributeName: resourceType
+          AttributeType: S
+        - AttributeName: lastUpdateDate
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+        - AttributeName: resourceType
+          KeyType: RANGE
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: resourceTypeIndex
+          KeySchema:
+            - AttributeName: resourceType
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL


### PR DESCRIPTION
# Description

This pull request adds DynamoDB Integration to Dashboard APIs.
Currently, it requires manual steps to start a DynamoDB local instance to run the core locally. I'm working on automating that step to eliminate manual steps.
However, the e2e test does NOT require manual steps to start a DynamoDB local instance and would start a `jest-dynamodb` local instance and run against that.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] e2e tests updated and passing with 82.9% statements coverage
- [x] linter passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
