### PR TITLE
feat: append authorization header

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -18,8 +18,8 @@
     "@cloudscape-design/global-styles": "^1.0.6",
     "@iot-app-kit/dashboard": "^3.0.0-alpha.3",
     "@iot-app-kit/source-iotsitewise": "^2.6.5",
-    "aws-amplify": "^5.0.12",
     "core-types": "*",
+    "lib": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "turbo run test:watch"
   },
   "dependencies": {
+    "aws-amplify": "^5.0.12",
     "core-types": "*"
   },
   "devDependencies": {

--- a/packages/lib/jest-setup.ts
+++ b/packages/lib/jest-setup.ts
@@ -1,0 +1,3 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+
+enableFetchMocks();

--- a/packages/lib/jest.config.ts
+++ b/packages/lib/jest.config.ts
@@ -4,12 +4,13 @@ import baseConfig from 'jest-config/base';
 
 const config: Config = {
   ...baseConfig,
-  collectCoverageFrom: ['**/src/**/*.{js,ts}'],
+  collectCoverageFrom: ['**/src/**/*.{js,ts}', '!**/src/**/index.ts'],
   displayName: 'lib',
   moduleFileExtensions: ['js', 'json', 'ts'],
   moduleNameMapper: {
     '^ky$': 'ky/distribution',
   },
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   testEnvironment: 'node',
   transform: {
     '^.+\\.ts?$': 'ts-jest',

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,6 +24,7 @@
     "eslint-config-custom": "*",
     "jest-config": "*",
     "jest-environment-jsdom": "^29.4.3",
+    "jest-fetch-mock": "^3.0.3",
     "tsconfig": "*"
   }
 }

--- a/packages/lib/src/auth/auth.hook.spec.ts
+++ b/packages/lib/src/auth/auth.hook.spec.ts
@@ -1,0 +1,17 @@
+import { createAuthorizationHook, GetJwt } from './auth.hook';
+
+describe('createAuthorizationHook', () => {
+  test('jwt is appended to header', async () => {
+    const jwtStub = 'abc.123.xyz';
+    const mockGetJwt: GetJwt = jest.fn().mockResolvedValue(jwtStub);
+    const authHook = createAuthorizationHook(mockGetJwt);
+
+    const request = new Request('');
+
+    expect(request.headers.has('Authorization')).toBe(false);
+
+    await authHook(request);
+
+    expect(request.headers.has('Authorization')).toBe(true);
+  });
+});

--- a/packages/lib/src/auth/auth.hook.ts
+++ b/packages/lib/src/auth/auth.hook.ts
@@ -1,0 +1,10 @@
+const appendAuthorizationHeader = (jwt: string, request: Request) => {
+  request.headers.set('Authorization', `Bearer: ${jwt}`);
+};
+
+export type GetJwt = () => Promise<string>;
+export const createAuthorizationHook =
+  (getJwt: GetJwt) => async (request: Request) => {
+    const jwt = await getJwt();
+    appendAuthorizationHeader(jwt, request);
+  };

--- a/packages/lib/src/auth/index.ts
+++ b/packages/lib/src/auth/index.ts
@@ -1,0 +1,10 @@
+import { Auth } from 'aws-amplify';
+
+import { createAuthorizationHook } from './auth.hook';
+
+const getAmplifyJwt = async () => {
+  const session = await Auth.currentSession();
+  return session.getAccessToken().getJwtToken();
+};
+
+export const authorizationHook = createAuthorizationHook(getAmplifyJwt);

--- a/packages/lib/src/http/http.types.ts
+++ b/packages/lib/src/http/http.types.ts
@@ -1,6 +1,8 @@
 import type ky from 'ky';
 import type { Options } from 'ky';
 
+export type { BeforeRequestHook } from 'ky';
+
 export interface HttpClient {
   get: typeof ky.get;
   post: typeof ky.post;

--- a/packages/lib/src/http/index.ts
+++ b/packages/lib/src/http/index.ts
@@ -1,10 +1,15 @@
 import ky from 'ky';
 
 import { HttpService } from './http.service';
+import { authorizationHook } from '../auth';
 
-export default new HttpService(
+export * from './http.types';
+
+export const http = new HttpService(
   ky.create({
     prefixUrl: 'http://localhost:3000',
-    hooks: {},
+    hooks: {
+      beforeRequest: [authorizationHook],
+    },
   }),
 );


### PR DESCRIPTION
# Description

This change extends the global http client to append authorization headers to outgoing requests. Core integration has not been thoroughly tested. In a follow-up PR, the client will be used to fetch dashboards and the integration logic will be tested further and corrected, if needed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Build passes locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
