### PR TITLE
feat: use rimraf instead of rm -rf

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "react-app-rewired build",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf build && rm -rf *.tsbuildinfo",
+    "clean": "rimraf .turbo && rimraf node_modules && rimraf dist && rimraf build && rimraf *.tsbuildinfo",
     "dev": "PORT=3001 react-app-rewired start",
     "gen:intl": "formatjs extract \"src/**/*.ts*\" --ignore=\"**/*.d.ts\" --out-file lang/en.json --id-interpolation-pattern \"[sha512:contenthash:base64:6]\"",
     "lint": "tsc --noEmit && TIMING=1 eslint \"src/**/*.ts*\" --max-warnings 0",

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "nest build core",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf *.tsbuildinfo",
+    "clean": "rimraf .turbo && rimraf node_modules && rimraf dist && rimraf *.tsbuildinfo",
     "dev": "yarn cognito-local & nest build --webpack --webpackPath webpack-hmr.config.js --watch",
     "start": "nest start",
     "start:debug": "nest start --debug --watch",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "clean": "rimraf .turbo && rimraf node_modules",
     "watch": "tsc -w",
     "cdk": "cdk",
     "lint": "TIMING=1 eslint \"{bin,lib}/**/*.ts\" --max-warnings 0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "iot-application",
   "private": true,
   "version": "0.0.0",
-  "workspaces": ["apps/*", "cdk", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "cdk",
+    "packages/*"
+  ],
   "config": {
     "docs": "http://localhost:3000/docs-json",
     "genpath": "apps/client/src/services/generated",
@@ -10,7 +14,7 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "clean": "turbo run clean && rm -rf .turbo && rm -rf node_modules && rm -rf *.tsbuildinfo",
+    "clean": "turbo run clean && rimraf .turbo && rimraf *.tsbuildinfo && rimraf node_modules",
     "dev": "turbo run dev",
     "gen:types": "openapi -i ${npm_package_config_docs} -o ${npm_package_config_genpath} ${npm_package_config_genconfig} && yarn format:gen:types",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
@@ -34,6 +38,7 @@
     "openapi-typescript": "^6.1.1",
     "openapi-typescript-codegen": "^0.23.0",
     "prettier": "^2.8.1",
+    "rimraf": "^4.4.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.0.0",
     "turbo": "latest",

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "clean": "rm -rf .turbo && rm -rf node_modules"
+    "clean": "rimraf .turbo && rimraf node_modules"
   },
   "dependencies": {
     "eslint-config-prettier": "^8.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19535,6 +19535,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.4.1.tgz#bd33364f67021c5b79e93d7f4fa0568c7c21b755"
+  integrity sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==
+  dependencies:
+    glob "^9.2.0"
+
 rollup-plugin-terser@^7.0.0:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"


### PR DESCRIPTION
# Description

Swapping `rm-rf` for `rimraf` for slight performance gain. Takes off ~1.5 second off my personal clean time (11.5s -> 10s on average on M2 Pro MBP). Will have a larger impact on older machines.

Also added clean script to `cdk` package.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
