### PR TITLE
fix: dashboard styling

### DIFF
--- a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
@@ -5,6 +5,7 @@ import invariant from 'tiny-invariant';
 import { DashboardLoadingState } from './components/dashboard-loading-state';
 import { useDashboardQuery } from '~/routes/dashboards/dashboard/hooks/use-dashboard-query';
 import { useUpdateDashboardMutation } from '~/routes/dashboards/dashboard/hooks/use-update-dashboard-mutation';
+import './styles.css';
 
 import type { Dashboard } from '~/services';
 

--- a/apps/client/src/routes/dashboards/dashboard/styles.css
+++ b/apps/client/src/routes/dashboards/dashboard/styles.css
@@ -1,0 +1,4 @@
+/* Prevent conflicting box sizing coming from Amplify */
+.dashboard * {
+  box-sizing: initial;
+}


### PR DESCRIPTION
# Description

Prevent Amplify global style setting from conflicting with IoT App Kit dashboard styles.

This change resolves https://github.com/awslabs/iot-application/issues/109.

It's not an ideal fix, but it works.

Before:

<img width="344" alt="Screenshot 2023-04-09 at 11 27 30" src="https://user-images.githubusercontent.com/67283114/230787325-23bb5f03-530e-4b4e-b05c-777295180526.png">

After:

<img width="425" alt="Screenshot 2023-04-09 at 11 26 15" src="https://user-images.githubusercontent.com/67283114/230787330-ccb77861-aa27-48be-a07c-34e6338714c8.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Inspected locally

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
