### PR TITLE
test: improve notification structure test coverage

### DIFF
--- a/apps/client/src/structures/notifications/error-notification.spec.ts
+++ b/apps/client/src/structures/notifications/error-notification.spec.ts
@@ -1,0 +1,12 @@
+import { ErrorNotification } from './error-notification';
+import { Notification } from './notification';
+
+describe('ErrorNotification', () => {
+  it('should create an error notification', () => {
+    const notification = new ErrorNotification('test');
+
+    expect(notification).toBeInstanceOf(Notification);
+    expect(notification.type).toBe('error');
+    expect(notification.content).toBe('test');
+  });
+});

--- a/apps/client/src/structures/notifications/error-notification.ts
+++ b/apps/client/src/structures/notifications/error-notification.ts
@@ -5,14 +5,3 @@ export class ErrorNotification extends Notification {
     super('error', content);
   }
 }
-
-if (import.meta.vitest) {
-  const { it, expect } = import.meta.vitest;
-
-  it('should create an error notification', () => {
-    const notification = new ErrorNotification('test');
-
-    expect(notification.type).toBe('error');
-    expect(notification.content).toBe('test');
-  });
-}

--- a/apps/client/src/structures/notifications/generic-error-notification.spec.ts
+++ b/apps/client/src/structures/notifications/generic-error-notification.spec.ts
@@ -1,0 +1,14 @@
+import { ErrorNotification } from './error-notification';
+import { GenericErrorNotification } from './generic-error-notification';
+import { Notification } from './notification';
+
+describe('GenericErrorNotification', () => {
+  it('should create a generic error notification', () => {
+    const notification = new GenericErrorNotification(new Error('test'));
+
+    expect(notification).toBeInstanceOf(ErrorNotification);
+    expect(notification).toBeInstanceOf(Notification);
+    expect(notification.type).toBe('error');
+    expect(notification.content).toBe('test');
+  });
+});

--- a/apps/client/src/structures/notifications/generic-error-notification.ts
+++ b/apps/client/src/structures/notifications/generic-error-notification.ts
@@ -5,14 +5,3 @@ export class GenericErrorNotification extends ErrorNotification {
     super(error.message);
   }
 }
-
-if (import.meta.vitest) {
-  const { it, expect } = import.meta.vitest;
-
-  it('should create a generic error notification', () => {
-    const notification = new GenericErrorNotification(new Error('test'));
-
-    expect(notification.type).toBe('error');
-    expect(notification.content).toBe('test');
-  });
-}

--- a/apps/client/src/structures/notifications/notification.spec.ts
+++ b/apps/client/src/structures/notifications/notification.spec.ts
@@ -1,0 +1,13 @@
+import { Notification } from './notification';
+
+describe('Notification', () => {
+  it.each(['info', 'success', 'warning', 'error'] as const)(
+    'should create a notification with type %s',
+    (type) => {
+      const notification = new Notification(type, 'test');
+
+      expect(notification.type).toBe(type);
+      expect(notification.content).toBe('test');
+    },
+  );
+});

--- a/apps/client/src/structures/notifications/notification.ts
+++ b/apps/client/src/structures/notifications/notification.ts
@@ -6,17 +6,3 @@ export class Notification {
     public readonly content: NotificationViewModel['content'],
   ) {}
 }
-
-if (import.meta.vitest) {
-  const { it, expect } = import.meta.vitest;
-
-  it.each(['info', 'success', 'warning', 'error'] as const)(
-    'should create a notification with type %s',
-    (type) => {
-      const notification = new Notification(type, 'test');
-
-      expect(notification.type).toBe(type);
-      expect(notification.content).toBe('test');
-    },
-  );
-}

--- a/apps/client/src/structures/notifications/success-notification.spec.ts
+++ b/apps/client/src/structures/notifications/success-notification.spec.ts
@@ -1,0 +1,12 @@
+import { Notification } from './notification';
+import { SuccessNotification } from './success-notification';
+
+describe('SuccessNotification', () => {
+  it('should create a success notification', () => {
+    const notification = new SuccessNotification('test');
+
+    expect(notification).toBeInstanceOf(Notification);
+    expect(notification.type).toBe('success');
+    expect(notification.content).toBe('test');
+  });
+});

--- a/apps/client/src/structures/notifications/success-notification.ts
+++ b/apps/client/src/structures/notifications/success-notification.ts
@@ -5,14 +5,3 @@ export class SuccessNotification extends Notification {
     super('success', content);
   }
 }
-
-if (import.meta.vitest) {
-  const { it, expect } = import.meta.vitest;
-
-  it('should create a success notification', () => {
-    const notification = new SuccessNotification('test');
-
-    expect(notification.type).toBe('success');
-    expect(notification.content).toBe('test');
-  });
-}


### PR DESCRIPTION
# Description

The change brings test coverage to 100% for each notification structure by validating the instance type. 

The tests were moved out of the implementation files, as it appears code coverage does not work well with in-source testing (the tests themselves get considered part of untested code... sometimes....). We may want to consider discarding the pattern if such is the case.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
