### PR TITLE
fix: inline table editing does not retain validation error after cancel

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -37,21 +37,7 @@ jobs:
       - name: Start Server 👨‍🍳
         run: yarn dev &
 
-      - name: Store Playwright Version 🆚
-        run: |
-          PLAYWRIGHT_VERSION=$(yarn list @playwright/test | grep @playwright | sed 's/.*@//')
-          echo "Playwright version: $PLAYWRIGHT_VERSION"
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
-
-      - name: Cache Playwright Browsers for Playwright Version 🤑
-        id: cache-playwright-browsers
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
-
       - name: Install Playwright Browsers 🔩
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: yarn playwright install --with-deps
 
       - name: Run Playwright tests 🧑‍🔬

--- a/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.tsx
@@ -9,20 +9,19 @@ import Link from '@cloudscape-design/components/link';
 import Modal from '@cloudscape-design/components/modal';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { DevTool } from '@hookform/devtools';
-import { useMutation } from '@tanstack/react-query';
 import { useForm, Controller } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import invariant from 'tiny-invariant';
 
-import { invalidateDashboards, invalidateDashboard } from '~/data/dashboards';
+import { invalidateDashboards } from '~/data/dashboards';
 import { isApiError } from '~/helpers/predicates/is-api-error';
 import { isJust } from '~/helpers/predicates';
 import { useEmitNotification } from '~/hooks/notifications/use-emit-notification';
-import { deleteDashboard } from '~/services';
 import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
 import { SuccessNotification } from '~/structures/notifications/success-notification';
 
 import type { DashboardSummary } from '~/services';
+import { useDeleteDashboardMutation } from '../hooks/use-delete-dashboard-mutation';
 
 const DELETE_CONSENT_TEXT = 'confirm' as const;
 
@@ -42,10 +41,7 @@ export function DeleteDashboardModal(props: DeleteDashboardModalProps) {
     reset,
   } = useForm({ defaultValues: { consent: '' } });
 
-  const mutation = useMutation({
-    mutationFn: (dashboard: DashboardSummary) => deleteDashboard(dashboard.id),
-    onSuccess: (_data, variables) => void invalidateDashboard(variables.id),
-  });
+  const mutation = useDeleteDashboardMutation();
 
   function handleDelete() {
     props.dashboards.forEach((dashboard) => {

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
@@ -1,0 +1,212 @@
+import { vi } from 'vitest';
+import { render, screen, waitFor } from '~/helpers/tests/testing-library';
+import userEvent from '@testing-library/user-event';
+
+import { DashboardsIndexPage } from './dashboards-index-page';
+import { DashboardSummary } from '~/services';
+
+const navigateMock = vi.fn();
+vi.mock('~/hooks/application/use-application', () => ({
+  useApplication: () => ({
+    navigate: navigateMock,
+  }),
+}));
+
+vi.mock('./hooks/use-dashboards-query', () => ({
+  useDashboardsQuery: vi.fn().mockReturnValue({
+    data: [
+      {
+        id: '123456789012',
+        name: 'test name',
+        description: 'test description',
+        lastUpdateDate: '2021-01-01T00:00:00.000Z',
+        creationDate: '2021-01-01T00:00:00.000Z',
+      },
+    ] satisfies DashboardSummary[],
+    isLoading: false,
+  }),
+}));
+
+vi.mock('./hooks/use-partial-update-dashboard-mutation', () => ({
+  usePartialUpdateDashboardMutation: vi.fn().mockReturnValue({
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock('./hooks/use-delete-dashboard-mutation', () => ({
+  useDeleteDashboardMutation: vi.fn().mockReturnValue({
+    mutate: vi.fn(),
+  }),
+}));
+
+// TODO: Find a way to reduce duplication of strings
+const getDashboardNameField = () =>
+  screen.getByPlaceholderText('Enter dashboard name');
+const queryDashboardNameField = () =>
+  screen.queryByPlaceholderText('Enter dashboard name');
+
+const getDashboardNameCell = (name: string) =>
+  screen.getByRole('cell', { name });
+
+const getDashboardNameRequiredError = () =>
+  screen.getByText('Dashboard name is required.');
+const queryDashboardNameRequiredError = () =>
+  screen.queryByText('Dashboard name is required.');
+
+const getDashboardNameTooLongError = () =>
+  screen.getByText('Dashboard name must be 40 characters or less.');
+const queryDashboardNameTooLongError = () =>
+  screen.queryByText('Dashboard name must be 40 characters or less.');
+
+const getDashboardDescriptionField = () =>
+  screen.getByPlaceholderText('Enter dashboard description');
+const queryDashboardDescriptionField = () =>
+  screen.queryByPlaceholderText('Enter dashboard description');
+
+const getDashboardDescriptionCell = (description: string) =>
+  screen.getByRole('cell', { name: description });
+
+const getDashboardDescriptionRequiredError = () =>
+  screen.getByText('Dashboard description is required.');
+const queryDashboardDescriptionRequiredError = () =>
+  screen.queryByText('Dashboard description is required.');
+
+const getDashboardDescriptionTooLongError = () =>
+  screen.getByText('Dashboard description must be 200 characters or less.');
+const queryDashboardDescriptionTooLongError = () =>
+  screen.queryByText('Dashboard description must be 200 characters or less.');
+
+const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' });
+
+describe('<DashboardsIndexPage />', () => {
+  describe('inline editing', () => {
+    it('should render a validation error when the name is empty', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      expect(queryDashboardNameField()).not.toBeInTheDocument();
+
+      await waitFor(async () => {
+        await user.click(getDashboardNameCell('test name'));
+      });
+
+      expect(getDashboardNameField()).toBeVisible();
+      expect(queryDashboardNameRequiredError()).not.toBeInTheDocument();
+
+      await waitFor(async () => {
+        await user.clear(getDashboardNameField());
+      });
+
+      expect(getDashboardNameRequiredError()).toBeVisible();
+    });
+
+    it('should render a validation error when the name is too long', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      await waitFor(async () => {
+        await user.click(getDashboardNameCell('test name'));
+      });
+
+      expect(queryDashboardNameTooLongError()).not.toBeInTheDocument();
+
+      await waitFor(async () => {
+        await user.clear(getDashboardNameField());
+        await user.type(getDashboardNameField(), 'a'.repeat(41));
+      });
+
+      expect(getDashboardNameTooLongError()).toBeVisible();
+    });
+
+    it('should remove the name validation error on cancel', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      await waitFor(async () => {
+        await user.click(getDashboardNameCell('test name'));
+        await user.clear(getDashboardNameField());
+        await user.click(getCancelButton());
+      });
+
+      expect(queryDashboardNameRequiredError()).not.toBeInTheDocument();
+    });
+
+    it('should not retain the name validation error on cancel', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      await waitFor(async () => {
+        await user.click(getDashboardNameCell('test name'));
+        await user.clear(getDashboardNameField());
+        await user.click(getCancelButton());
+        await user.click(getDashboardNameCell('test name'));
+      });
+
+      expect(queryDashboardNameRequiredError()).not.toBeInTheDocument();
+    });
+
+    it('should render a validation error when the description is empty', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      expect(queryDashboardDescriptionField()).not.toBeInTheDocument();
+
+      await waitFor(async () => {
+        await user.click(getDashboardDescriptionCell('test description'));
+      });
+
+      expect(queryDashboardDescriptionRequiredError()).not.toBeInTheDocument();
+
+      await waitFor(async () => {
+        await user.clear(getDashboardDescriptionField());
+      });
+
+      expect(getDashboardDescriptionRequiredError()).toBeVisible();
+    });
+
+    it('should render a validation error when the description is too long', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      await waitFor(async () => {
+        await user.click(getDashboardDescriptionCell('test description'));
+      });
+
+      expect(queryDashboardDescriptionTooLongError()).not.toBeInTheDocument();
+
+      await waitFor(async () => {
+        await user.clear(getDashboardDescriptionField());
+        await user.type(getDashboardDescriptionField(), 'a'.repeat(201));
+      });
+
+      expect(getDashboardDescriptionTooLongError()).toBeVisible();
+    });
+
+    it('should remove the description validation error on cancel', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      await waitFor(async () => {
+        await user.click(getDashboardDescriptionCell('test description'));
+        await user.clear(getDashboardDescriptionField());
+        await user.click(getCancelButton());
+      });
+
+      expect(queryDashboardDescriptionRequiredError()).not.toBeInTheDocument();
+    });
+
+    it('should not retain the description validation error on cancel', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      await waitFor(async () => {
+        await user.click(getDashboardDescriptionCell('test description'));
+        await user.clear(getDashboardDescriptionField());
+        await user.click(getCancelButton());
+        await user.click(getDashboardDescriptionCell('test description'));
+      });
+
+      expect(queryDashboardDescriptionRequiredError()).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '~/helpers/tests/testing-library';
 import userEvent from '@testing-library/user-event';
 
 import { DashboardsIndexPage } from './dashboards-index-page';
-import { DashboardSummary } from '~/services';
+import { DashboardSummary, $Dashboard } from '~/services';
 
 const navigateMock = vi.fn();
 vi.mock('~/hooks/application/use-application', () => ({
@@ -54,9 +54,9 @@ const queryDashboardNameRequiredError = () =>
   screen.queryByText('Dashboard name is required.');
 
 const getDashboardNameTooLongError = () =>
-  screen.getByText('Dashboard name must be 40 characters or less.');
+  screen.getByText(/Dashboard name must be \d+ characters or less./);
 const queryDashboardNameTooLongError = () =>
-  screen.queryByText('Dashboard name must be 40 characters or less.');
+  screen.queryByText(/Dashboard name must be \d+ characters or less./);
 
 const getDashboardDescriptionField = () =>
   screen.getByPlaceholderText('Enter dashboard description');
@@ -72,9 +72,9 @@ const queryDashboardDescriptionRequiredError = () =>
   screen.queryByText('Dashboard description is required.');
 
 const getDashboardDescriptionTooLongError = () =>
-  screen.getByText('Dashboard description must be 200 characters or less.');
+  screen.getByText(/Dashboard description must be \d+ characters or less./);
 const queryDashboardDescriptionTooLongError = () =>
-  screen.queryByText('Dashboard description must be 200 characters or less.');
+  screen.queryByText(/Dashboard description must be \d+ characters or less./);
 
 const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' });
 
@@ -110,10 +110,18 @@ describe('<DashboardsIndexPage />', () => {
 
       expect(queryDashboardNameTooLongError()).not.toBeInTheDocument();
 
-      await waitFor(async () => {
-        await user.clear(getDashboardNameField());
-        await user.type(getDashboardNameField(), 'a'.repeat(41));
-      });
+      await waitFor(
+        async () => {
+          await user.clear(getDashboardNameField());
+          await user.type(
+            getDashboardNameField(),
+            'a'.repeat($Dashboard.properties.name.maxLength + 1),
+          );
+        },
+        {
+          timeout: 5000,
+        },
+      );
 
       expect(getDashboardNameTooLongError()).toBeVisible();
     });
@@ -122,11 +130,16 @@ describe('<DashboardsIndexPage />', () => {
       const user = userEvent.setup();
       render(<DashboardsIndexPage />);
 
-      await waitFor(async () => {
-        await user.click(getDashboardNameCell('test name'));
-        await user.clear(getDashboardNameField());
-        await user.click(getCancelButton());
-      });
+      await waitFor(
+        async () => {
+          await user.click(getDashboardNameCell('test name'));
+          await user.clear(getDashboardNameField());
+          await user.click(getCancelButton());
+        },
+        {
+          timeout: 5000,
+        },
+      );
 
       expect(queryDashboardNameRequiredError()).not.toBeInTheDocument();
     });
@@ -135,12 +148,17 @@ describe('<DashboardsIndexPage />', () => {
       const user = userEvent.setup();
       render(<DashboardsIndexPage />);
 
-      await waitFor(async () => {
-        await user.click(getDashboardNameCell('test name'));
-        await user.clear(getDashboardNameField());
-        await user.click(getCancelButton());
-        await user.click(getDashboardNameCell('test name'));
-      });
+      await waitFor(
+        async () => {
+          await user.click(getDashboardNameCell('test name'));
+          await user.clear(getDashboardNameField());
+          await user.click(getCancelButton());
+          await user.click(getDashboardNameCell('test name'));
+        },
+        {
+          timeout: 5000,
+        },
+      );
 
       expect(queryDashboardNameRequiredError()).not.toBeInTheDocument();
     });
@@ -174,10 +192,18 @@ describe('<DashboardsIndexPage />', () => {
 
       expect(queryDashboardDescriptionTooLongError()).not.toBeInTheDocument();
 
-      await waitFor(async () => {
-        await user.clear(getDashboardDescriptionField());
-        await user.type(getDashboardDescriptionField(), 'a'.repeat(201));
-      });
+      await waitFor(
+        async () => {
+          await user.clear(getDashboardDescriptionField());
+          await user.type(
+            getDashboardDescriptionField(),
+            'a'.repeat($Dashboard.properties.description.maxLength + 1),
+          );
+        },
+        {
+          timeout: 5000,
+        },
+      );
 
       expect(getDashboardDescriptionTooLongError()).toBeVisible();
     });
@@ -186,11 +212,16 @@ describe('<DashboardsIndexPage />', () => {
       const user = userEvent.setup();
       render(<DashboardsIndexPage />);
 
-      await waitFor(async () => {
-        await user.click(getDashboardDescriptionCell('test description'));
-        await user.clear(getDashboardDescriptionField());
-        await user.click(getCancelButton());
-      });
+      await waitFor(
+        async () => {
+          await user.click(getDashboardDescriptionCell('test description'));
+          await user.clear(getDashboardDescriptionField());
+          await user.click(getCancelButton());
+        },
+        {
+          timeout: 5000,
+        },
+      );
 
       expect(queryDashboardDescriptionRequiredError()).not.toBeInTheDocument();
     });
@@ -199,12 +230,17 @@ describe('<DashboardsIndexPage />', () => {
       const user = userEvent.setup();
       render(<DashboardsIndexPage />);
 
-      await waitFor(async () => {
-        await user.click(getDashboardDescriptionCell('test description'));
-        await user.clear(getDashboardDescriptionField());
-        await user.click(getCancelButton());
-        await user.click(getDashboardDescriptionCell('test description'));
-      });
+      await waitFor(
+        async () => {
+          await user.click(getDashboardDescriptionCell('test description'));
+          await user.clear(getDashboardDescriptionField());
+          await user.click(getCancelButton());
+          await user.click(getDashboardDescriptionCell('test description'));
+        },
+        {
+          timeout: 5000,
+        },
+      );
 
       expect(queryDashboardDescriptionRequiredError()).not.toBeInTheDocument();
     });

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -26,6 +26,7 @@ export function DashboardsIndexPage() {
     control,
     formState: { errors },
     getValues,
+    reset: resetForm,
   } = useForm({
     defaultValues: { name: '', description: '' },
     mode: 'onChange',
@@ -58,6 +59,7 @@ export function DashboardsIndexPage() {
             [column.id]: getValues(column.id),
           });
         }}
+        onEditCancel={() => resetForm()}
         header={
           <DashboardsTableHeader
             isDeleteDisabled={selectedItems.length === 0}

--- a/apps/client/src/routes/dashboards/dashboards-index/hooks/use-delete-dashboard-mutation.ts
+++ b/apps/client/src/routes/dashboards/dashboards-index/hooks/use-delete-dashboard-mutation.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+import { deleteDashboard } from '~/services';
+import { invalidateDashboard } from '~/data/dashboards';
+
+import type { DashboardSummary } from '~/services';
+
+export function useDeleteDashboardMutation() {
+  return useMutation({
+    mutationFn: (dashboard: DashboardSummary) => deleteDashboard(dashboard.id),
+    onSuccess: (_data, variables) => void invalidateDashboard(variables.id),
+  });
+}

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
     includeSource: ['src/**/*.{js,ts}'],
     reporters: ['verbose', 'html'],
     setupFiles: './src/test/setup.ts',
+    testTimeout: 10000, // for safety in CI
   },
   define: {
     // enable removal from production code

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -1,8 +1,4 @@
-import {
-  defineConfig,
-  defaultExclude,
-  coverageConfigDefaults,
-} from 'vitest/config';
+import { defineConfig, coverageConfigDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
@@ -38,10 +34,10 @@ export default defineConfig({
        *
        * Please increase the coverage levels as you add tests.
        */
-      statements: 22,
-      branches: 53,
-      functions: 23,
-      lines: 22,
+      statements: 46,
+      branches: 66,
+      functions: 35,
+      lines: 46,
       watermarks: {
         statements: [80, 95],
         branches: [80, 95],
@@ -54,7 +50,7 @@ export default defineConfig({
     includeSource: ['src/**/*.{js,ts}'],
     reporters: ['verbose', 'html'],
     setupFiles: './src/test/setup.ts',
-    testTimeout: 10000, // for safety in CI
+    singleThread: true,
   },
   define: {
     // enable removal from production code

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,13 +10,13 @@ export default defineConfig({
   },
   testDir: './tests',
   /* Maximum time one test can run for. */
-  timeout: 30000,
+  timeout: 60000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 10000,
+    timeout: 30000,
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
@@ -25,8 +25,10 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? '50%' : undefined,
   projects: [
-    { name: 'setup', testMatch: /.*\.setup\.ts/ },
-
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts/,
+    },
     {
       name: 'chromium',
       use: {


### PR DESCRIPTION
# Description

The change resolves https://github.com/awslabs/iot-application/issues/103.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
