### PR TITLE
feat: increase dashboard name limit from 40 characters to 100 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ Visualize your AWS IoT data with the IoT Application.
    ```sh
    yarn dev
    ```
+1. Log in with local Cognito credentials found at `apps/core/.cognito/db`
 
 ## Running the tests locally
 
 Run local test command `yarn test` to test the application. The command is "batteries included" - it has everything needed to run and test the application locally.
+
+## Updating generated types locally
+
+Run `yarn gen:types` in root while `yarn dev` is running.
 
 ## Deploying to AWS Cloud
 
@@ -48,8 +53,8 @@ Run local test command `yarn test` to test the application. The command is "batt
 
 The table below lists the service dependencies for different environments.
 
-| Catagory\Environments | [Local Develoepment](#getting-started-with-local-development)                                | [Local Test](#running-the-tests-locally)                                              |
-|-----------------------|----------------------------------------------------------------|-----------------------------------------------------------------------|
+| Category\Environments | [Local Development](#getting-started-with-local-development)   | [Local Test](#running-the-tests-locally)                              |
+| --------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------- |
 | Authentication        | [cognito-local](https://www.npmjs.com/package/cognito-local)   | [cognito-local](https://www.npmjs.com/package/cognito-local)          |
 | App API Database      | [dynamodb-local](https://www.npmjs.com/package/dynamodb-local) | [dynamodb-local](https://www.npmjs.com/package/dynamodb-local)        |
 | App API Authorization | [cognito-local](https://www.npmjs.com/package/cognito-local)   | [JWT generated from secret](./apps/core/src/testing/jwt-generator.ts) |

--- a/apps/client/src/services/generated/schemas/$CreateDashboardDto.ts
+++ b/apps/client/src/services/generated/schemas/$CreateDashboardDto.ts
@@ -6,7 +6,7 @@ export const $CreateDashboardDto = {
     name: {
       type: 'string',
       isRequired: true,
-      maxLength: 40,
+      maxLength: 100,
       minLength: 1,
     },
     description: {

--- a/apps/client/src/services/generated/schemas/$Dashboard.ts
+++ b/apps/client/src/services/generated/schemas/$Dashboard.ts
@@ -12,7 +12,7 @@ export const $Dashboard = {
     name: {
       type: 'string',
       isRequired: true,
-      maxLength: 40,
+      maxLength: 100,
       minLength: 1,
     },
     description: {

--- a/apps/client/src/services/generated/schemas/$DashboardSummary.ts
+++ b/apps/client/src/services/generated/schemas/$DashboardSummary.ts
@@ -12,7 +12,7 @@ export const $DashboardSummary = {
     name: {
       type: 'string',
       isRequired: true,
-      maxLength: 40,
+      maxLength: 100,
       minLength: 1,
     },
     description: {

--- a/apps/client/src/services/generated/schemas/$UpdateDashboardDto.ts
+++ b/apps/client/src/services/generated/schemas/$UpdateDashboardDto.ts
@@ -6,7 +6,7 @@ export const $UpdateDashboardDto = {
     name: {
       type: 'string',
       isRequired: true,
-      maxLength: 40,
+      maxLength: 100,
       minLength: 1,
     },
     description: {

--- a/apps/core/src/dashboards/dashboard.constants.ts
+++ b/apps/core/src/dashboards/dashboard.constants.ts
@@ -10,3 +10,7 @@ export const DATABASE_GSI = {
 export const MESSAGES = {
   ITEM_NOT_FOUND_ERROR: 'Missing dashboard data or definition',
 };
+
+export const DASHBOARD_NAME_MAX_LENGTH = 100;
+
+export const DASHBOARD_DESCRIPTION_MAX_LENGTH = 200;

--- a/apps/core/src/dashboards/dashboards.e2e.spec.ts
+++ b/apps/core/src/dashboards/dashboards.e2e.spec.ts
@@ -13,7 +13,11 @@ import { Test } from '@nestjs/testing';
 import { instanceToPlain, plainToClass } from 'class-transformer';
 import { nanoid } from 'nanoid';
 
-import { RESOURCE_TYPES } from './dashboard.constants';
+import {
+  RESOURCE_TYPES,
+  DASHBOARD_NAME_MAX_LENGTH,
+  DASHBOARD_DESCRIPTION_MAX_LENGTH,
+} from './dashboard.constants';
 import { CreateDashboardDto } from './dto/create-dashboard.dto';
 import { UpdateDashboardDto } from './dto/update-dashboard.dto';
 import { Dashboard } from './entities/dashboard.entity';
@@ -282,7 +286,7 @@ describe('DashboardsModule', () => {
       );
     });
 
-    test.each(['x', 'x'.repeat(10), 'x'.repeat(40)])(
+    test.each(['x', 'x'.repeat(10), 'x'.repeat(DASHBOARD_NAME_MAX_LENGTH)])(
       'returns 201 when name is valid: (%s)',
       async (dashboardName) => {
         const payload: CreateDashboardDto = {
@@ -303,7 +307,7 @@ describe('DashboardsModule', () => {
       },
     );
 
-    test.each(['', 'x'.repeat(41), 1, {}, []])(
+    test.each(['', 'x'.repeat(DASHBOARD_NAME_MAX_LENGTH + 1), 1, {}, []])(
       'returns 400 when name is not valid: (%s)',
       async (dashboardName) => {
         const payload = {
@@ -341,7 +345,11 @@ describe('DashboardsModule', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    test.each(['x', 'x'.repeat(10), 'x'.repeat(200)])(
+    test.each([
+      'x',
+      'x'.repeat(10),
+      'x'.repeat(DASHBOARD_DESCRIPTION_MAX_LENGTH),
+    ])(
       'returns 201 when description is valid: (%s)',
       async (dashboardDescription) => {
         const payload: CreateDashboardDto = {
@@ -758,7 +766,13 @@ describe('DashboardsModule', () => {
       },
     );
 
-    test.each(['', 'x'.repeat(201), 1, {}, []])(
+    test.each([
+      '',
+      'x'.repeat(DASHBOARD_DESCRIPTION_MAX_LENGTH + 1),
+      1,
+      {},
+      [],
+    ])(
       'returns 400 when description is not valid: (%s)',
       async (dashboardDescription) => {
         const dashboard = await seedTestDashboard('name');

--- a/apps/core/src/dashboards/entities/dashboard.entity.ts
+++ b/apps/core/src/dashboards/entities/dashboard.entity.ts
@@ -8,6 +8,10 @@ import {
 } from 'class-validator';
 
 import { DashboardDefinition } from './dashboard-definition.entity';
+import {
+  DASHBOARD_NAME_MAX_LENGTH,
+  DASHBOARD_DESCRIPTION_MAX_LENGTH,
+} from '../dashboard.constants';
 
 export type DashboardId = string;
 export type DashboardName = string;
@@ -25,14 +29,14 @@ export class Dashboard {
    * @example "Wind Farm 4"
    */
   @IsString()
-  @Length(1, 40)
+  @Length(1, DASHBOARD_NAME_MAX_LENGTH)
   public readonly name: DashboardName;
 
   /**
    * @example "Wind Farm 4 Description"
    */
   @IsString()
-  @Length(1, 200)
+  @Length(1, DASHBOARD_DESCRIPTION_MAX_LENGTH)
   public readonly description: DashboardDescription;
 
   @IsObject()

--- a/tests/pages/create-dashboard.page.ts
+++ b/tests/pages/create-dashboard.page.ts
@@ -12,7 +12,7 @@ export class CreateDashboardPage {
   readonly descriptionRequiredError: Locator;
   readonly nameMaxLengthError: Locator;
   readonly descriptionMaxLengthError: Locator;
-  readonly nameMaxLength = 40;
+  readonly nameMaxLength = 100;
   readonly descriptionMaxLength = 200;
 
   private readonly url = 'dashboards/create';
@@ -29,7 +29,7 @@ export class CreateDashboardPage {
       'Dashboard description is required.',
     );
     this.nameMaxLengthError = page.getByText(
-      'Dashboard name must be 40 characters or less.',
+      'Dashboard name must be 100 characters or less.',
     );
     this.descriptionMaxLengthError = page.getByText(
       'Dashboard description must be 200 characters or less',


### PR DESCRIPTION
# Description

Dashboard name should have a limit of 100 characters instead of 40. Added some documentation for generating types and finding local cognito credentials.

Resolves https://app.asana.com/0/1203518413061418/1204350041304188/f

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated tests for dashboard name in core
- [x] Updated tests for dashboard description in core
- [x] Updated create dashboard tests in client

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
