### PR TITLE
feat: page not found page

### DIFF
--- a/apps/client/src/layout/hooks/use-format.ts
+++ b/apps/client/src/layout/hooks/use-format.ts
@@ -1,10 +1,7 @@
 import { useMatches } from 'react-router-dom';
 import invariant from 'tiny-invariant';
 
-import {
-  isHandleableWithFormat,
-  isListWithSingleItem,
-} from '~/helpers/predicates';
+import { isHandleableWithFormat, isJust } from '~/helpers/predicates';
 
 import type { MaybeFormatted, MaybeHandleable } from '~/types';
 
@@ -16,9 +13,7 @@ export function useFormat() {
 
   const matchesWithFormat = matches.filter(isHandleableWithFormat);
 
-  if (!isListWithSingleItem(matchesWithFormat)) {
-    invariant(false, 'Expected only 1 match with format');
-  }
-
-  return matchesWithFormat[0].handle.format;
+  return isJust(matchesWithFormat[0])
+    ? matchesWithFormat[0].handle.format
+    : 'default';
 }

--- a/apps/client/src/routes/root/root-error-page.spec.tsx
+++ b/apps/client/src/routes/root/root-error-page.spec.tsx
@@ -1,0 +1,29 @@
+import { vi } from 'vitest';
+import { render, screen } from '~/helpers/tests/testing-library';
+import userEvent from '@testing-library/user-event';
+
+import { RootErrorPage } from './root-error-page';
+
+const navigateMock = vi.fn();
+vi.mock('~/hooks/application/use-application', () => ({
+  useApplication: () => ({
+    navigate: navigateMock,
+  }),
+}));
+
+describe('<RootErrorPage />', () => {
+  it('should allow user to navigate to home page', async () => {
+    const user = userEvent.setup();
+    render(<RootErrorPage />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Page not found' }),
+    ).toBeVisible();
+
+    await user.click(
+      screen.getByRole('link', { name: 'IoT Application home page' }),
+    );
+
+    expect(navigateMock).toHaveBeenCalledWith('/');
+  });
+});

--- a/apps/client/src/routes/root/root-error-page.tsx
+++ b/apps/client/src/routes/root/root-error-page.tsx
@@ -1,0 +1,46 @@
+import Container from '@cloudscape-design/components/container';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import Link from '@cloudscape-design/components/link';
+import { useIntl, FormattedMessage } from 'react-intl';
+
+import { useApplication } from '~/hooks/application/use-application';
+
+export function RootErrorPage() {
+  const intl = useIntl();
+  const { navigate } = useApplication();
+
+  return (
+    <ContentLayout
+      header={
+        <Header
+          variant="h1"
+          description={intl.formatMessage({
+            defaultMessage: 'The page you are looking for does not exist',
+            description: 'page not found header description',
+          })}
+        >
+          <FormattedMessage
+            defaultMessage="Page not found"
+            description="page not found header"
+          />
+        </Header>
+      }
+    >
+      <Container>
+        <Link
+          href="/"
+          onFollow={(event) => {
+            event.preventDefault();
+            navigate('/');
+          }}
+        >
+          <FormattedMessage
+            defaultMessage="IoT Application home page"
+            description="page not found link"
+          />
+        </Link>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/apps/client/src/routes/root/root-page.spec.tsx
+++ b/apps/client/src/routes/root/root-page.spec.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '~/helpers/tests/testing-library';
+
+import { RootPage } from './root-page';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+describe('<RootPage />', () => {
+  it('should render outlet', () => {
+    render(
+      <MemoryRouter>
+        <Routes>
+          <Route element={<RootPage />}>
+            <Route index element={<div>test page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('test page')).toBeVisible();
+  });
+});

--- a/apps/client/src/routes/root/root-page.tsx
+++ b/apps/client/src/routes/root/root-page.tsx
@@ -1,15 +1,11 @@
 import { Outlet } from 'react-router-dom';
 
-import { Layout } from '../../layout/layout';
-
 import { RootErrorBoundary } from './components/root-error-boundary';
 
 export function RootPage() {
   return (
-    <Layout>
-      <RootErrorBoundary>
-        <Outlet />
-      </RootErrorBoundary>
-    </Layout>
+    <RootErrorBoundary>
+      <Outlet />
+    </RootErrorBoundary>
   );
 }

--- a/apps/client/src/routes/root/root-route.tsx
+++ b/apps/client/src/routes/root/root-route.tsx
@@ -5,10 +5,21 @@ import { ROOT_PATH, ROOT_HREF } from '~/constants';
 import { intl } from '~/services';
 
 import type { RouteObject } from 'react-router-dom';
+import { RootErrorPage } from './root-error-page';
+import { Layout } from '~/layout/layout';
 
 export const rootRoute = {
   path: ROOT_PATH,
-  element: <RootPage />,
+  element: (
+    <Layout>
+      <RootPage />
+    </Layout>
+  ),
+  errorElement: (
+    <Layout>
+      <RootErrorPage />
+    </Layout>
+  ),
   handle: {
     activeHref: ROOT_HREF,
     crumb: () => ({

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -125,4 +125,19 @@ test.describe('Navigation', () => {
       })();
     });
   });
+
+  test('as a user, I see a page not found page when I navigate to a non-existent page', async ({
+    page,
+  }) => {
+    await page.goto('this-page-does-not-exist');
+
+    await expect(
+      page.getByRole('heading', { name: 'Page not found' }),
+    ).toBeVisible();
+
+    // TODO: add a screenshot once https://github.com/awslabs/iot-application/pull/122 is merged
+    await page.getByRole('link', { name: 'IoT Application home page' }).click();
+
+    await expect(page).toHaveURL('/');
+  });
 });


### PR DESCRIPTION
# Description

The change adds a page not found page (`<RootPage />`) to the application for the catch-all error element.

Additionally, the change includes:
- Movement of `<Layout />` instantiation outside of `<RootPage />` to enable simple unit tests of `<RootPage />` and `<RootErrorPage />`.
- 100% test coverage achieved for `<RootPage />` by testing `<Outlet />` render. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test for `<RootErrorPage />` (100% test coverage)
- [x] Playwright test for the page not found page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
