### PR TITLE
feat: dashboard name in breadcrumbs

### DIFF
--- a/apps/client/src/routes/dashboards/dashboard/dashboard-route.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-route.tsx
@@ -3,7 +3,13 @@ import { DashboardErrorBoundary } from './components/dashboard-error-boundary';
 import { DASHBOARD_PAGE_FORMAT } from '~/constants/format';
 import { DASHBOARD_PATH } from '~/constants';
 
-import type { RouteObject } from 'react-router-dom';
+import { queryClient } from '~/data/query-client';
+
+import { type RouteObject } from 'react-router-dom';
+import { createDashboardQuery } from '~/data/dashboards';
+import { Auth } from 'aws-amplify';
+import invariant from 'tiny-invariant';
+import { Dashboard } from '~/services';
 
 export const dashboardRoute = {
   path: DASHBOARD_PATH,
@@ -12,12 +18,22 @@ export const dashboardRoute = {
       <DashboardPage />
     </DashboardErrorBoundary>
   ),
+  loader: async ({ params }) => {
+    invariant(params.dashboardId, 'Expected dashboardId is to be defined');
+    /**
+     * The loader is called before the element is rendered. This means we need
+     * to wait for authentication state before we can fetch the dashboard.
+     */
+    await Auth.currentAuthenticatedUser();
+    return queryClient.fetchQuery(createDashboardQuery(params.dashboardId));
+  },
   handle: {
-    crumb: () => ({
-      // TODO: replace with real dashboard name
-      text: 'Dashboard',
-      href: '',
-    }),
+    crumb: (dashboard: Dashboard) => {
+      return {
+        text: dashboard.name,
+        href: '',
+      };
+    },
     fullWidth: true,
     format: DASHBOARD_PAGE_FORMAT,
   },

--- a/tests/dashboards/dashboard-management.spec.ts
+++ b/tests/dashboards/dashboard-management.spec.ts
@@ -42,8 +42,8 @@ test('as a user, I can create, update, and delete my dashboard', async ({
   await expect(dashboardRow).toBeVisible();
 
   await page.getByRole('link', { name: 'My dashboard' }).click();
-
   await expect(page).toHaveURL(/dashboards\/[a-zA-Z0-9_-]{12}/);
+
   await page.getByRole('button', { name: 'Save' }).click();
 
   await expect(application.notification).toBeVisible();


### PR DESCRIPTION
# Description

The change adds the dashboard name to the breadcrumb component by using a `react-router` loader.

The change resolves https://github.com/awslabs/iot-application/issues/91.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Playwright test added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
