### PR TITLE
fix: CloudFront to respond with /index.html for not found asset requests

### DIFF
--- a/cdk/lib/asset/public-asset-stack.ts
+++ b/cdk/lib/asset/public-asset-stack.ts
@@ -95,6 +95,13 @@ export class PublicAssetStack extends Stack {
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         },
         defaultRootObject: 'index.html',
+        errorResponses: [
+          {
+            httpStatus: 404,
+            responseHttpStatus: 200,
+            responsePagePath: '/index.html',
+          },
+        ],
       },
     );
     this.publicDistribution.node.addDependency(


### PR DESCRIPTION
# Description

This behavior is necessary to support browser route. For example, dashboard page with route `/dashboards/uEP_1WhILGN9` would be an 404 response otherwise.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Deployed and verified the behavior (able to resolve to `/index.html` while `x-cache: Error from cloudfront`)
<img width="594" alt="Screenshot 2023-04-12 at 3 36 57 PM" src="https://user-images.githubusercontent.com/50635800/231601478-a31879e5-3ee7-4415-b253-d92ed8c0d0f6.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
