### PR TITLE
fix: delete dashboard consent input label

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.spec.tsx
@@ -1,0 +1,131 @@
+import { vi } from 'vitest';
+import { render, screen } from '~/helpers/tests/testing-library';
+import userEvent from '@testing-library/user-event';
+
+import { DeleteDashboardModal } from './delete-dashboard-modal';
+import type { DeleteDashboardModalProps } from './delete-dashboard-modal';
+
+const mockDelete = vi.fn();
+vi.mock('../hooks/use-delete-dashboard-mutation', () => ({
+  useDeleteDashboardMutation: () => ({
+    mutate: mockDelete,
+  }),
+}));
+
+const getDeleteButton = () => screen.getByRole('button', { name: 'Delete' });
+const getConsentInput = () =>
+  screen.getByLabelText(/^To confirm this deletion/);
+
+describe('DeleteDashboardModal', () => {
+  const defaultProps = {
+    dashboards: [
+      {
+        id: '1',
+        name: 'Dashboard 1',
+        description: 'description',
+        lastUpdateDate: new Date('2000-01-01').toLocaleDateString(),
+        creationDate: new Date('2000-01-01').toLocaleDateString(),
+      },
+    ],
+    isVisible: true,
+    onClose: vi.fn(),
+  } as const satisfies DeleteDashboardModalProps;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('single dashboard', () => {
+    test('delete button is enabled with consent given', async () => {
+      render(<DeleteDashboardModal {...defaultProps} />);
+      const user = userEvent.setup();
+
+      await user.type(getConsentInput(), 'confirm');
+      expect(getConsentInput()).toBeEnabled();
+      await user.click(getDeleteButton());
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+      expect(mockDelete).toHaveBeenCalledWith(
+        defaultProps.dashboards[0],
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('multiple dashboards', () => {
+    const multipleDashboardsProps = {
+      ...defaultProps,
+      dashboards: [
+        ...defaultProps.dashboards,
+        {
+          id: '2',
+          name: 'Dashboard 2',
+          description: 'description',
+          lastUpdateDate: new Date('2000-01-01').toLocaleDateString(),
+          creationDate: new Date('2000-01-01').toLocaleDateString(),
+        },
+      ],
+    } as const satisfies DeleteDashboardModalProps;
+
+    test('delete button is enabled with consent given', async () => {
+      render(<DeleteDashboardModal {...multipleDashboardsProps} />);
+      const user = userEvent.setup();
+
+      await user.type(getConsentInput(), 'confirm');
+      expect(getConsentInput()).toBeEnabled();
+      await user.click(getDeleteButton());
+      expect(mockDelete).toHaveBeenCalledTimes(2);
+      expect(mockDelete).toHaveBeenNthCalledWith(
+        1,
+        multipleDashboardsProps.dashboards[0],
+        expect.anything(),
+      );
+      expect(mockDelete).toHaveBeenNthCalledWith(
+        2,
+        multipleDashboardsProps.dashboards[1],
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('invalid consent', () => {
+    test('delete button is disabled without consent given', async () => {
+      render(<DeleteDashboardModal {...defaultProps} />);
+      const user = userEvent.setup();
+
+      expect(getDeleteButton()).toBeDisabled();
+      await user.click(getDeleteButton());
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    test('delete button is disabled with consent is removed', async () => {
+      render(<DeleteDashboardModal {...defaultProps} />);
+      const user = userEvent.setup();
+
+      await user.type(getConsentInput(), 'confirm');
+      await user.clear(getConsentInput());
+      expect(getDeleteButton()).toBeDisabled();
+      await user.click(getDeleteButton());
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    test('delete button is disabled when consent text is incorrect', async () => {
+      render(<DeleteDashboardModal {...defaultProps} />);
+      const user = userEvent.setup();
+
+      await user.type(getConsentInput(), 'incorrect');
+      expect(getDeleteButton()).toBeDisabled();
+      await user.click(getDeleteButton());
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    test('delete button is disabled when consent text is incomplete', async () => {
+      render(<DeleteDashboardModal {...defaultProps} />);
+      const user = userEvent.setup();
+
+      await user.type(getConsentInput(), 'conf');
+      expect(getDeleteButton()).toBeDisabled();
+      await user.click(getDeleteButton());
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.tsx
@@ -25,7 +25,7 @@ import { useDeleteDashboardMutation } from '../hooks/use-delete-dashboard-mutati
 
 const DELETE_CONSENT_TEXT = 'confirm' as const;
 
-interface DeleteDashboardModalProps {
+export interface DeleteDashboardModalProps {
   dashboards: readonly DashboardSummary[];
   isVisible: boolean;
   onClose: () => void;
@@ -160,6 +160,7 @@ export function DeleteDashboardModal(props: DeleteDashboardModalProps) {
               defaultMessage="Proceeding with this action will delete the dashboard with all its content and can affect related resources."
               description="delete dashboard modal warning message"
             />
+            {/* spacing before link */ ' '}
             <Link
               external={true}
               href="https://github.com/awslabs/iot-application"
@@ -178,35 +179,44 @@ export function DeleteDashboardModal(props: DeleteDashboardModalProps) {
             />
           </Box>
 
-          <ColumnLayout columns={2}>
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
 
-                void handleSubmit(() => {
-                  handleDelete();
-                })();
-              }}
-            >
-              <Form>
-                <Controller
-                  name="consent"
-                  control={control}
-                  rules={{ required: true, pattern: /^confirm$/ }}
-                  render={({ field }) => (
-                    <FormField>
+              void handleSubmit(() => {
+                handleDelete();
+              })();
+            }}
+          >
+            <Form>
+              <Controller
+                name="consent"
+                control={control}
+                rules={{ required: true, pattern: /^confirm$/ }}
+                render={({ field }) => (
+                  <FormField
+                    label={intl.formatMessage(
+                      {
+                        defaultMessage:
+                          'To confirm this deletion, type "{deleteConsentText}"',
+                        description: 'delete dashboard modal consent label',
+                      },
+                      { deleteConsentText: DELETE_CONSENT_TEXT },
+                    )}
+                  >
+                    <ColumnLayout columns={2}>
                       <Input
                         ariaRequired
                         placeholder={DELETE_CONSENT_TEXT}
                         onChange={(event) => field.onChange(event.detail.value)}
                         value={field.value}
                       />
-                    </FormField>
-                  )}
-                />
-              </Form>
-            </form>
-          </ColumnLayout>
+                    </ColumnLayout>
+                  </FormField>
+                )}
+              />
+            </Form>
+          </form>
         </SpaceBetween>
       </Modal>
 


### PR DESCRIPTION
# Description

The change adds a label to the delete dashboard consent input, matching the experiencing of the [Cloudscape pattern demo](https://cloudscape.design/examples/react/delete-with-additional-confirmation.html).

<img width="619" alt="Screenshot 2023-04-17 at 12 07 09" src="https://user-images.githubusercontent.com/67283114/232572715-ba2cbfc9-a7dd-48c2-b757-cf6cbcb477e7.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
