### PR TITLE
fix: id sort and table edit

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/components/dashboards-table-preferences.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/dashboards-table-preferences.tsx
@@ -104,12 +104,13 @@ export function DashboardsTablePreferences(
             }),
             options: [
               {
-                id: 'dashboard-id',
+                id: 'id',
                 label: intl.formatMessage({
                   defaultMessage: 'ID',
                   description:
                     'dashboards table preferences visible content id',
                 }),
+                editable: false,
               },
               {
                 id: 'name',
@@ -118,7 +119,6 @@ export function DashboardsTablePreferences(
                   description:
                     'dashboards table preferences visible content name',
                 }),
-                editable: false,
               },
               {
                 id: 'description',

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
@@ -12,17 +12,21 @@ vi.mock('~/hooks/application/use-application', () => ({
   }),
 }));
 
+function getDashboardStubs() {
+  return [
+    {
+      id: '123456789012',
+      name: 'test name',
+      description: 'test description',
+      lastUpdateDate: '2021-01-01T00:00:00.000Z',
+      creationDate: '2021-01-01T00:00:00.000Z',
+    },
+  ] as const satisfies Readonly<DashboardSummary[]>;
+}
+
 vi.mock('./hooks/use-dashboards-query', () => ({
   useDashboardsQuery: vi.fn().mockReturnValue({
-    data: [
-      {
-        id: '123456789012',
-        name: 'test name',
-        description: 'test description',
-        lastUpdateDate: '2021-01-01T00:00:00.000Z',
-        creationDate: '2021-01-01T00:00:00.000Z',
-      },
-    ] satisfies DashboardSummary[],
+    data: getDashboardStubs(),
     isLoading: false,
   }),
 }));
@@ -38,6 +42,8 @@ vi.mock('./hooks/use-delete-dashboard-mutation', () => ({
     mutate: vi.fn(),
   }),
 }));
+
+const getDashboardLink = (id: string) => screen.getByRole('link', { name: id });
 
 // TODO: Find a way to reduce duplication of strings
 const getDashboardNameField = () =>
@@ -79,6 +85,18 @@ const queryDashboardDescriptionTooLongError = () =>
 const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' });
 
 describe('<DashboardsIndexPage />', () => {
+  describe('navigation to dashboard', () => {
+    it('should navigate to the dashboard when the id is clicked', async () => {
+      render(<DashboardsIndexPage />);
+
+      await userEvent.click(getDashboardLink(getDashboardStubs()[0].id));
+
+      expect(navigateMock).toHaveBeenCalledWith(
+        `/dashboards/${getDashboardStubs()[0].id}`,
+      );
+    });
+  });
+
   describe('inline editing', () => {
     it('should render a validation error when the name is empty', async () => {
       const user = userEvent.setup();

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -68,19 +68,10 @@ export function DashboardsIndexPage() {
         }
         columnDefinitions={[
           {
-            id: 'dashboard-id',
+            id: 'id',
             header: intl.formatMessage({
               defaultMessage: 'ID',
               description: 'dashboards table ID column header',
-            }),
-            cell: (dashboard) => dashboard.id,
-            sortingField: 'dashboard-id',
-          },
-          {
-            id: 'name',
-            header: intl.formatMessage({
-              defaultMessage: 'Name',
-              description: 'dashboards table name column header',
             }),
             cell: (dashboard) => (
               <Link
@@ -93,9 +84,18 @@ export function DashboardsIndexPage() {
                   navigate(event.detail.href);
                 }}
               >
-                {dashboard.name}
+                {dashboard.id}
               </Link>
             ),
+            sortingField: 'id',
+          },
+          {
+            id: 'name',
+            header: intl.formatMessage({
+              defaultMessage: 'Name',
+              description: 'dashboards table name column header',
+            }),
+            cell: (dashboard) => dashboard.name,
             sortingField: 'name',
             editConfig: {
               ariaLabel: intl.formatMessage({

--- a/apps/client/src/routes/dashboards/dashboards-index/hooks/use-dashboards-table.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/hooks/use-dashboards-table.tsx
@@ -54,9 +54,7 @@ export function useDashboardsTable() {
       pagination: <Pagination {...paginationProps} />,
       preferences: (
         <DashboardsTablePreferences
-          onConfirm={(event) =>
-            setPreferences(event.detail as typeof preferences)
-          }
+          onConfirm={(event) => setPreferences(event.detail)}
           preferences={preferences}
         />
       ),

--- a/apps/client/src/routes/dashboards/dashboards-index/hooks/use-table-preferences.ts
+++ b/apps/client/src/routes/dashboards/dashboards-index/hooks/use-table-preferences.ts
@@ -1,18 +1,34 @@
-import { useLocalStorage } from 'react-use';
+import type { CollectionPreferencesProps } from '@cloudscape-design/components';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 const PREFERENCES_KEY = 'table-preferences';
 const DEFAULT_PREFERENCES = {
   pageSize: 10,
   wrapLines: true,
   stripedRows: false,
-  visibleContent: ['name', 'description', 'lastUpdateDate'],
+  visibleContent: ['name', 'description'],
+};
+const NON_PREFERENCES = {
+  // ensure that the id column is always visible
+  visibleContent: ['id'],
 };
 
+/**
+ * Hook to get and set table preferences in local storage.
+ */
 export function useTablePreferences() {
-  const [preferences = DEFAULT_PREFERENCES, setPreferences] = useLocalStorage(
-    PREFERENCES_KEY,
-    DEFAULT_PREFERENCES,
-  );
+  const [preferences = DEFAULT_PREFERENCES, setPreferences] = useLocalStorage<
+    CollectionPreferencesProps<typeof DEFAULT_PREFERENCES>['preferences']
+  >(PREFERENCES_KEY, DEFAULT_PREFERENCES);
 
-  return [preferences, setPreferences] as const;
+  return [
+    {
+      ...preferences,
+      visibleContent: [
+        ...NON_PREFERENCES.visibleContent,
+        ...(preferences.visibleContent ?? []),
+      ],
+    },
+    setPreferences,
+  ] as const;
 }

--- a/tests/dashboards/dashboard-management.spec.ts
+++ b/tests/dashboards/dashboard-management.spec.ts
@@ -41,7 +41,7 @@ test('as a user, I can create, update, and delete my dashboard', async ({
   });
   await expect(dashboardRow).toBeVisible();
 
-  await page.getByRole('link', { name: 'My dashboard' }).click();
+  await page.getByRole('link', { name: /[a-zA-Z0-9_-]{12}/ }).click();
   await expect(page).toHaveURL(/dashboards\/[a-zA-Z0-9_-]{12}/);
 
   await page.getByRole('button', { name: 'Save' }).click();


### PR DESCRIPTION
# Description

This change includes two fixes:
1. ID column sorting now works.
2. Preventing inline edit before dashboard link.

The second fix was accomplished by making the ID column visibility required by default and using it to navigate. The UX aligns with the [Cloudscape table inline edit pattern](https://cloudscape.design/examples/react/table-editable.html).

<img width="1321" alt="Screenshot 2023-04-17 at 12 55 11" src="https://user-images.githubusercontent.com/67283114/232584385-dde964b2-ca62-4ebd-88f9-7a9192d2dbb7.png"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests added
- [x] e2e test modified

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
