### PR TITLE
fix: prevent diagram action from creating commit

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -1,20 +1,27 @@
 name: Create diagram
 
 on:
-  workflow_dispatch: {}
   push:
-    branches:
-      - main
+    branches: main
 
 jobs:
-  get_data:
+  diagram:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@master
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
 
-      - name: Update diagram
+      - name: Create diagram 🎨
         uses: githubocto/repo-visualizer@0.7.1
         with:
-          output_file: 'images/diagram.svg'
+          artifact_name: diagram
+          should_push: false
+          output_file: diagram.svg
           excluded_paths: 'dist,node_modules,ignore,.github'
+
+      # retrieve diagram from workflow output
+      # diagram in README.md is updated manually
+      - name: Download diagram 📝
+        uses: actions/download-artifact@v3
+        with:
+          name: diagram


### PR DESCRIPTION
# Description

The diagram action is failing because it is attempting to commit directly to main. This change sets the action to instead download the diagram artifact, which can be retrieved from the workflow output. The artifact then must be manually updated. The change is not requiring a manual step for every change. We don’t need to update the diagram often.