### PR TITLE
feat(client): persist viewport setting in local storage

### DIFF
--- a/apps/client/src/hooks/dashboard/use-viewport.ts
+++ b/apps/client/src/hooks/dashboard/use-viewport.ts
@@ -1,0 +1,10 @@
+import { useLocalStorage } from 'react-use';
+import type { Viewport } from '@iot-app-kit/core';
+
+const DEFAULT_VIEWPORT: Viewport = { duration: '5 minutes' };
+export const useViewport = (dashboardId: string) => {
+  return useLocalStorage<Viewport>(
+    `dashboard-${dashboardId}-viewport`,
+    DEFAULT_VIEWPORT,
+  );
+};

--- a/tests/dashboards/dashboard-management.spec.ts
+++ b/tests/dashboards/dashboard-management.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { CreateDashboardPage } from '../pages/create-dashboard.page';
 import {
   DashboardsIndexPage,
@@ -44,11 +44,21 @@ test('as a user, I can create, update, and delete my dashboard', async ({
   await page.getByRole('link', { name: /[a-zA-Z0-9_-]{12}/ }).click();
   await expect(page).toHaveURL(/dashboards\/[a-zA-Z0-9_-]{12}/);
 
+  // check if viewport setting persists
+  await page.getByRole('button', { name: 'Time machine' }).click();
+  await page.getByRole('radio', { name: 'Last 10 minutes' }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
   await page.getByRole('button', { name: 'Save' }).click();
 
   await expect(application.notification).toBeVisible();
   await expect(application.notification).toHaveText(
     'Successfully updated dashboard "My Dashboard".',
+  );
+
+  await page.reload();
+  await expect(page.getByRole('button', { name: 'Time machine' })).toHaveText(
+    'Last 10 minutes',
   );
 
   await dashboardsPage.goto();


### PR DESCRIPTION
# Description

Persist viewport setting in local storage as `dashboard-<dashboard-id>-viewport`.

Fixes # (issue) https://app.asana.com/0/1204375185707273/1204402749215391

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] local unit test
- [x] local e2e test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
