### PR TITLE
fix: suppress type error

### DIFF
--- a/apps/core/src/health/indicators/dynamodb.health.spec.ts
+++ b/apps/core/src/health/indicators/dynamodb.health.spec.ts
@@ -8,6 +8,9 @@ import { DynamoDbHealthIndicator } from './dynamodb.health';
 import { mockClient } from 'aws-sdk-client-mock';
 
 describe('HealthController', () => {
+  // there is a type error after upgrading local dyanmodb client
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
   const ddbMock = mockClient(DynamoDBClient);
   let dynamoDbHealthIndicator: DynamoDbHealthIndicator;
 
@@ -25,6 +28,9 @@ describe('HealthController', () => {
 
   describe('check', () => {
     test('returns up status', async () => {
+      // there is a type error after upgrading local dyanmodb client
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
       ddbMock.on(DescribeTableCommand).resolves({});
 
       const result = dynamoDbHealthIndicator.check('db');
@@ -36,6 +42,9 @@ describe('HealthController', () => {
     });
 
     test('returns down status', async () => {
+      // there is a type error after upgrading local dyanmodb client
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
       ddbMock.on(DescribeTableCommand).rejects();
 
       const result = dynamoDbHealthIndicator.check('db');


### PR DESCRIPTION
# Description

Upon upgrading our local dynamodb client, a type error appeared in the dynamodb health indicator tests. It's not clear at this time how to resolve the error. This change suppresses the type error with a TypeScript comment that an error is expected until we can resolve this issue. The tests still run without an issue.

Resolves https://github.com/awslabs/iot-application/issues/218.