### PR TITLE
ci: run only on changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,51 @@
+name: Lint PR
+
+run-name: Lint PR action initiated by ${{ github.actor }}
+
+on:
+  pull_request:
+    branches: main
+
+jobs:
+  lint-pr:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          # checkout full tree
+          fetch-depth: 0
+
+      - name: Install Java 🔧
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+
+      - name: Install Node.js 🔧
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install Dependencies 🔩
+        run: yarn install --frozen-lockfile
+
+      - name: Lint Commits 🐰
+        run: |
+          PR_OWNER="${{ github.event.pull_request.head.repo.owner.login }}"
+          PR_REPO="${{ github.event.pull_request.head.repo.name }}"
+          PR_BRANCH="${{ github.head_ref }}"
+
+          git remote add pr https://github.com/$PR_OWNER/$PR_REPO.git
+          git fetch pr $PR_BRANCH
+
+          BASE_SHA=$(git rev-parse ${{ github.event.pull_request.base.sha }})
+          HEAD_SHA=$(git rev-parse ${{ github.event.pull_request.head.sha }})
+
+          git rev-list $BASE_SHA..$HEAD_SHA | while read commit; do
+            git checkout $commit
+            yarn lint:commit || exit 1
+          done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,6 @@ run-name: Lint action initiated by ${{ github.actor }}
 on:
   push:
     branches: main
-  pull_request:
-    branches: main
 
 jobs:
   lint:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,50 @@
+name: Unit Test PR
+
+run-name: Unit Test PR action initiated by ${{ github.actor }}
+
+on:
+  pull_request:
+    branches: main
+
+jobs:
+  test-pr:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Java 🔧
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+
+      - name: Install Node.js 🔧
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install Dependencies 🔩
+        run: yarn install --frozen-lockfile
+
+      - name: Unit Test Commits 🧑‍🔬
+        run: |
+          PR_OWNER="${{ github.event.pull_request.head.repo.owner.login }}"
+          PR_REPO="${{ github.event.pull_request.head.repo.name }}"
+          PR_BRANCH="${{ github.head_ref }}"
+
+          git remote add pr https://github.com/$PR_OWNER/$PR_REPO.git
+          git fetch pr $PR_BRANCH
+
+          BASE_SHA=$(git rev-parse ${{ github.event.pull_request.base.sha }})
+          HEAD_SHA=$(git rev-parse ${{ github.event.pull_request.head.sha }})
+
+          git rev-list $BASE_SHA..$HEAD_SHA | while read commit; do
+            git checkout $commit
+            yarn test:commit || exit 1
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ run-name: Unit Test action initiated by ${{ github.actor }}
 on:
   push:
     branches: main
-  pull_request:
-    branches: main
 
 jobs:
   test:

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -2,14 +2,18 @@
   "name": "client",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": false,
   "scripts": {
-    "build": "react-app-rewired build",
+    "analyze": "source-map-explorer build/static/js/*.js",
+    "build": "DISABLE_ESLINT_PLUGIN=true react-app-rewired build",
     "clean": "rimraf .turbo && rimraf node_modules && rimraf dist && rimraf build && rimraf *.tsbuildinfo",
     "dev": "PORT=3001 react-app-rewired start",
     "gen:intl": "formatjs extract \"src/**/*.ts*\" --ignore=\"**/*.d.ts\" --out-file lang/en.json --id-interpolation-pattern \"[sha512:contenthash:base64:6]\"",
     "lint": "tsc --noEmit && TIMING=1 eslint \"src/**/*.ts*\" --max-warnings 0",
+    "lint:commit": "tsc --noEmit && TIMING=1 eslint $(git diff --name-only HEAD HEAD~1 | grep -E \"src/**/*.ts*\" | xargs) --max-warnings 0",
     "lint:fix": "eslint \"src/**/*.ts*\" --fix",
     "test": "vitest run --coverage",
+    "test:commit": "vitest run --changed HEAD~1",
     "test:watch": "vitest",
     "test:ui": "vitest --ui"
   },
@@ -35,7 +39,6 @@
     "react-router-dom": "^6.11.1",
     "react-use": "^17.4.0",
     "tiny-invariant": "^1.3.1",
-    "typescript": "^5.0.4",
     "web-vitals": "^3.3.1"
   },
   "devDependencies": {
@@ -65,16 +68,13 @@
     "identity-obj-proxy": "^3.0.0",
     "react-app-rewired": "^2.2.1",
     "react-scripts": "^5.0.1",
+    "source-map-explorer": "^2.5.3",
     "tsconfig": "*",
-    "typescript": "^4.9.3",
+    "typescript": "^5.0.4",
     "vitest": "^0.31.0"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -10,9 +10,11 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "tsc --noEmit && TIMING=1 eslint \"{src,test}/**/*.ts\" --max-warnings 0",
+    "lint:commit": "tsc --noEmit && TIMING=1 eslint $(git diff --name-only HEAD HEAD~1 | grep -E \"src/**/*.ts\" | xargs) --max-warnings 0",
     "lint:fix": "eslint \"{src,test}/**/*.ts*\" --fix",
     "repl": "nest start --entryFile repl --watch",
     "test": "jest --coverage",
+    "test:commit": "jest --lastCommit",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -7,10 +7,11 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf .turbo && rimraf node_modules",
+    "clean": "rimraf .turbo && rimraf node_modules && rimraf dist",
     "watch": "tsc -w",
     "cdk": "cdk",
-    "lint": "TIMING=1 eslint \"{bin,lib}/**/*.ts\" --max-warnings 0"
+    "lint": "TIMING=1 eslint \"{bin,lib}/**/*.ts\" --max-warnings 0",
+    "lint:commit": "tsc --noEmit && TIMING=1 eslint $(git diff --name-only HEAD HEAD~1 | grep -E \"{bin,lib}/**/*.ts\" | xargs) --max-warnings 0"
   },
   "dependencies": {
     "aws-cdk-lib": "2.78.0",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,7 @@
   "name": "iot-application",
   "private": true,
   "version": "0.0.0",
-  "workspaces": [
-    "apps/*",
-    "cdk",
-    "packages/*"
-  ],
+  "workspaces": ["apps/*", "cdk", "packages/*"],
   "config": {
     "docs": "http://localhost:3000/docs-json",
     "genpath": "apps/client/src/services/generated",
@@ -20,10 +16,12 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:gen:types": "prettier --write \"${npm_package_config_genpath}/**/*.ts\"",
     "lint": "turbo run lint && tsc --noEmit && TIMING=1 eslint \"tests/**/*.ts\" --max-warnings 0",
+    "lint:commit": "turbo run lint:commit --filter=[HEAD~1]",
     "lint:fix": "turbo run lint:fix && eslint \"tests/**/*.ts\" --fix",
     "start:client": "cd apps/client && yarn dev && cd -",
     "start:core": "cd apps/core && yarn dev && cd -",
     "test": "turbo run test",
+    "test:commit": "turbo run test:commit --filter=[HEAD~1]",
     "test:e2e": "playwright test",
     "test:watch": "turbo run test:watch"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -2,8 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
-      "outputs": ["build/**", "dist/**"],
-      "dependsOn": ["^build"]
+      "outputs": ["build/**", "dist/**"]
     },
     "clean": {
       "cache": false
@@ -11,7 +10,6 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["^build"],
       "env": [
         "AWS_ACCESS_KEY_ID",
         "AWS_REGION",
@@ -26,16 +24,13 @@
         "DATABASE_LAUNCH_LOCAL"
       ]
     },
-    "lint": {
-      "dependsOn": ["^build"]
-    },
-    "lint:fix": {
-      "dependsOn": ["^build"]
-    },
+    "lint": {},
+    "lint:commit": {},
+    "lint:fix": {},
     "test": {
-      "dependsOn": ["^build"],
       "outputs": ["coverage/**"]
     },
+    "test:commit": {},
     "test:watch": {
       "cache": false
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12015,6 +12015,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -13620,7 +13625,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@^3.1.6:
+ejs@^3.1.5, ejs@^3.1.6:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
   integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
@@ -13834,7 +13839,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -15846,7 +15851,7 @@ is-windows@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
   integrity sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -17677,7 +17682,7 @@ minizlib@^1.3.3:
   dependencies:
     minipass "^2.9.0"
 
-mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -18079,6 +18084,14 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^7.3.1:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
 
 open@^8.0.9, open@^8.4.0:
   version "8.4.2"
@@ -20046,6 +20059,13 @@ rimraf@^5.0.0:
   dependencies:
     glob "^10.0.0"
 
+rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 rollup-plugin-terser@^7.0.0:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
@@ -20542,6 +20562,24 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-explorer@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-explorer/-/source-map-explorer-2.5.3.tgz#33551b51e33b70f56d15e79083cdd4c43e583b69"
+  integrity sha512-qfUGs7UHsOBE5p/lGfQdaAj/5U/GWYBw2imEpD6UQNkqElYonkow8t+HBL1qqIl3CuGZx7n8/CQo4x1HwSHhsg==
+  dependencies:
+    btoa "^1.2.1"
+    chalk "^4.1.0"
+    convert-source-map "^1.7.0"
+    ejs "^3.1.5"
+    escape-html "^1.0.3"
+    glob "^7.1.6"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    open "^7.3.1"
+    source-map "^0.7.4"
+    temp "^0.9.4"
+    yargs "^16.2.0"
+
 source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -20582,7 +20620,7 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@0.7.4, source-map@^0.7.3:
+source-map@0.7.4, source-map@^0.7.3, source-map@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
@@ -21120,6 +21158,14 @@ temp-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
   integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
+temp@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
+  integrity sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
+  dependencies:
+    mkdirp "^0.5.1"
+    rimraf "~2.6.2"
 
 tempy@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
# Description

This PR includes changes to improve the linting and testing workflows of the application.

Notable changes include:
- Increased the `timeout-minutes` value of the `build` job from 10 to 15 to add buffer for potentially slow runs.
- Added new workflows to run linting and unit tests on pull requests targeting the `main` branch. These workflows will check only the code changes in the pull request, instead of running the entire test suite.
- Removed the `pull_request` trigger from the existing linting and unit testing workflows to avoid redundant test runs and to instead only run on push to main.
- Added `"sideEffects": false` to the `client` package's `package.json` file to enable tree-shaking in production builds, which should reduce bundle size and increase build speed.
- Added new scripts for linting and testing individual Git commits, which should enable faster feedback and reduce test times.
- Added bundle analyzer to client to understand cost of dependencies.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
