### PR TITLE
feat: add regional config for deploying to different regions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:alpine as builder
+FROM --platform=linux/amd64 node:alpine as builder 
 
 WORKDIR /usr/src/app-build
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Run `yarn gen:types` in root while `yarn dev` is running.
 
 ## Deploying to AWS Cloud
 
+This will deploy the application to AWS using CDK.
+
+##### Prerequisites:
+
+1. Install docker: https://docs.docker.com/get-docker/
+1. For the initial deployment, bootstrap cdk in your account:
+   ```sh
+   yarn workspace cdk cdk bootstrap
+   ```
+
+##### Deployment to cloud:
+
 1. Install application dependencies:
    ```sh
    yarn install

--- a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
@@ -30,11 +30,13 @@ export function DashboardPage() {
     return <DashboardLoadingState />;
   }
 
+  const awsRegion = Auth.configure().region || 'us-west-2';
+
   return (
     <IoTAppKitDashboard
       clientConfiguration={{
         awsCredentials: () => Auth.currentCredentials(),
-        awsRegion: 'us-west-2',
+        awsRegion,
       }}
       dashboardConfiguration={{
         ...dashboardQuery.data?.definition,

--- a/cdk/lib/iot-application-stack.ts
+++ b/cdk/lib/iot-application-stack.ts
@@ -13,11 +13,11 @@ export class IotApplicationStack extends Stack {
       userPool: { userPoolId },
       userPoolClient: { userPoolClientId },
       identityPool: { ref: identityPoolId },
-    } = new AuthStack(this, 'Auth');
+    } = new AuthStack(this, 'Auth', props);
 
     const {
       resourceTable: { tableArn, tableName },
-    } = new DatabaseStack(this, 'Database');
+    } = new DatabaseStack(this, 'Database', props);
 
     const {
       coreService: { serviceUrl: coreServiceUrl },
@@ -28,6 +28,7 @@ export class IotApplicationStack extends Stack {
         userPoolClientId: userPoolClientId,
         userPoolId: userPoolId,
       },
+      ...props
     });
 
     const publicAssetStack = new PublicAssetStack(this, 'PublicAsset', {
@@ -35,6 +36,7 @@ export class IotApplicationStack extends Stack {
       userPoolClientId,
       userPoolId,
       coreServiceUrl: `https://${coreServiceUrl}`,
+      ...props
     });
     const { publicDistribution } = publicAssetStack;
 


### PR DESCRIPTION
# Description

We hardcoded `us-west-2` as a region for the SiteWise API requests on the client, so if this application was deployed in a different AWS region, they would see errors with dashboard requests due to incorrect region. This change allows the application to be deployed in any region. Instead of hardcoding, it gets the region for the client from the amplify auth config, which gets set by the CFN template or CDK code depending on the respective method of deployment.

Additionally, this change fixes a bug where cdk deployments on Mac’s with M1 processors weren’t working. It specifies the platform for the Dockerfile so the locally build image will always work on the AWS lambda instances.

I also added some prop arguments to the cdk stack creation, because without passing those prop arguments cdk would not allow me to create all the stacks due to cross-region and cross-account calls. It appears this happens because if the additional props which contain the env variable aren’t passed through, the child stacks don’t know which account/region to use for the deployment.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Deploy the CFN template to a different region. I deployed it to `us-east-1` and validated the dashboard requests were to the correct `us-east-1` endpoint and returned 200.
- [X] Deploy the CDK stacks to a different region. I deployed them to `us-east-1` and validated the dashboard requests were to the correct `us-east-1` endpoint and returned 200.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
