### PR TITLE
chore: e2e playwright test after deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install Dependencies 🔩
         run: yarn install --frozen-lockfile
 
-      - name: Build Application 👷
-        run: yarn workspace client build
+      # - name: Build Application 👷
+      #   run: yarn workspace client build
 
       - name: Configure AWS credentials 🔑
         uses: aws-actions/configure-aws-credentials@v2
@@ -50,6 +50,31 @@ jobs:
           role-to-assume: arn:aws:iam::506789550664:role/IotAppGithubActionRole-IotAppGithubRole-7P4GB3XPGF1V
           aws-region: us-west-2
 
-      - name: Deploy CDK 🚀
-        run: yarn workspace cdk cdk deploy --all --require-approval never
+      # - name: Deploy CDK 🚀
+      #   run: yarn workspace cdk cdk deploy --all --require-approval never
 
+      - name: Get App URL 🔗
+        id: app_url
+        run: |
+          app_url=$(aws cloudformation describe-stacks --stack-name IotApp --query "Stacks[0].Outputs[?OutputKey=='AppURL'].OutputValue" --output text)
+          echo "::set-output name=app_url::$app_url"
+          echo "app_url=$app_url" >> $GITHUB_OUTPUT
+
+      - name: Install Playwright Browsers 🔩
+        run: yarn playwright install --with-deps
+
+      - name: Run Playwright tests 🧑‍🔬
+        env:
+          ENDPOINT: ${{ steps.app_url.outputs.app_url }}
+          LAUNCH_WEB_SERVER: false
+          USER_PASSWORD: ${{ secrets.DEPLOYMENT_USER_PASSWORD }}
+        id: tests
+        run: yarn playwright test
+
+      - name: Store Test Artifacts on Failure 🥲
+        if: failure() && steps.tests.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install Dependencies 🔩
         run: yarn install --frozen-lockfile
 
-      # - name: Build Application 👷
-      #   run: yarn workspace client build
+      - name: Build Application 👷
+        run: yarn workspace client build
 
       - name: Configure AWS credentials 🔑
         uses: aws-actions/configure-aws-credentials@v2
@@ -50,8 +50,8 @@ jobs:
           role-to-assume: arn:aws:iam::506789550664:role/IotAppGithubActionRole-IotAppGithubRole-7P4GB3XPGF1V
           aws-region: us-west-2
 
-      # - name: Deploy CDK 🚀
-      #   run: yarn workspace cdk cdk deploy --all --require-approval never
+      - name: Deploy CDK 🚀
+        run: yarn workspace cdk cdk deploy --all --require-approval never
 
       - name: Get App URL 🔗
         id: app_url

--- a/apps/core/.cognito/db/us-west-2_h23TJjQR9.json
+++ b/apps/core/.cognito/db/us-west-2_h23TJjQR9.json
@@ -11,6 +11,10 @@
         {
           "Name": "email",
           "Value": "test-user@amazon.com"
+        },
+        {
+          "Name": "email_verified",
+          "Value": true
         }
       ],
       "Enabled": true,
@@ -257,7 +261,9 @@
       "AllowAdminCreateUserOnly": false,
       "UnusedAccountValidityDays": 7
     },
-    "UsernameAttributes": ["email"],
+    "UsernameAttributes": [
+      "email"
+    ],
     "Id": "us-west-2_h23TJjQR9"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,32 @@
 import { devices, defineConfig } from '@playwright/test';
 
+// Read environment variables
+// baseURL defaults to http://localhost:3001
+const baseURL = process.env.ENDPOINT ?? 'http://localhost:3001';
+// launchWebServer defaults to true
+const launchWebServer = process.env.LAUNCH_WEB_SERVER != 'false';
+
+// Configuration for launching the web server
+const launchWebServerConfig = [
+  {
+    command: 'yarn start:core',
+    url: 'http://localhost:3000/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 300 * 1000, // 5 minutes
+  },
+  {
+    command: 'yarn start:client',
+    url: 'http://localhost:3001',
+    reuseExistingServer: !process.env.CI,
+    timeout: 300 * 1000, // 5 minutes
+  },
+];
+// If launchWebServer is true, add the web server launching configuration
+const webServer = launchWebServer ? launchWebServerConfig : undefined;
+
 export default defineConfig({
   use: {
-    baseURL: 'http://localhost:3001',
+    baseURL,
     navigationTimeout: 30000,
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
@@ -57,18 +81,5 @@ export default defineConfig({
       dependencies: ['setup'],
     },
   ],
-  webServer: [
-    {
-      command: 'yarn start:core',
-      url: 'http://localhost:3000/health',
-      reuseExistingServer: !process.env.CI,
-      timeout: 300 * 1000, // 5 minutes
-    },
-    {
-      command: 'yarn start:client',
-      url: 'http://localhost:3001',
-      reuseExistingServer: !process.env.CI,
-      timeout: 300 * 1000, // 5 minutes
-    },
-  ],
+  webServer,
 });

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,5 +1,8 @@
 import { test as setup, expect } from '@playwright/test';
 
+// Read environment variables
+const userPassword = process.env.USER_PASSWORD ?? 'test-Password!';
+
 const authFile = 'playwright/.auth/user.json';
 
 setup('authenticate', async ({ page }) => {
@@ -11,13 +14,10 @@ setup('authenticate', async ({ page }) => {
 
   // user enters their credentials
   await page.getByLabel('Username').fill('test-user');
-  await page.getByLabel('Password').nth(0).fill('test-Password!');
+  await page.getByLabel('Password').nth(0).fill(userPassword);
 
   // user clicks sign-in
   await page.getByRole('button', { name: 'Sign in' }).click();
-
-  // user skips email verification
-  await page.getByRole('button', { name: 'Skip' }).click();
 
   // user lands at home page
   await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,13 @@
     "lint": {},
     "lint:commit": {},
     "lint:fix": {},
+    "playwright": {
+      "env": [
+        "ENDPOINT",
+        "LAUNCH_WEB_SERVER",
+        "USER_PASSWORD"
+      ]
+    },
     "test": {
       "outputs": ["coverage/**"]
     },


### PR DESCRIPTION
# Description

Added steps to run e2e playwright test against the deployment environment after deployment.
Note:
- Playwright test user `test-user` already created in Cognito User Pool.
- Repository secret `DEPLOYMENT_USER_PASSWORD` already added to [iot-application](https://github.com/awslabs/iot-application) with value of the test user's password.

# How Has This Been Tested?

See passing workflows

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
