### PR TITLE
fix: navigate to dashboard details page after creation

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
+    outputs:
+      app_url: ${{ steps.app_url.outputs.app_url }}
 
     steps:
       - name: Checkout 🛎️
@@ -59,12 +61,38 @@ jobs:
           app_url=$(aws cloudformation describe-stacks --stack-name IotApp --query "Stacks[0].Outputs[?OutputKey=='AppURL'].OutputValue" --output text)
           echo "app_url=$app_url" >> $GITHUB_OUTPUT
 
+  test:
+    needs: deploy
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Install Java 🔧
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+
+      - name: Install Node.js 🔧
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install Dependencies 🔩
+        run: yarn install --frozen-lockfile
+
       - name: Install Playwright Browsers 🔩
         run: yarn playwright install --with-deps
 
       - name: Run Playwright tests 🧑‍🔬
         env:
-          ENDPOINT: ${{ steps.app_url.outputs.app_url }}
+          ENDPOINT: ${{ needs.deploy.outputs.app_url }}
           LAUNCH_WEB_SERVER: false
           USER_PASSWORD: ${{ secrets.DEPLOYMENT_USER_PASSWORD }}
         id: tests

--- a/apps/client/src/routes/dashboards/create/hooks/use-create-dashboard-mutation.tsx
+++ b/apps/client/src/routes/dashboards/create/hooks/use-create-dashboard-mutation.tsx
@@ -3,7 +3,6 @@ import { useMutation } from '@tanstack/react-query';
 import { useIntl, FormattedMessage } from 'react-intl';
 import invariant from 'tiny-invariant';
 
-import { DASHBOARDS_HREF } from '~/constants';
 import {
   cancelDashboardsQueries,
   invalidateDashboards,
@@ -35,7 +34,7 @@ export function useCreateDashboardMutation() {
       await invalidateDashboards();
       await prefetchDashboards();
 
-      navigate(DASHBOARDS_HREF);
+      navigate(`/dashboards/${newDashboard.id}`);
 
       emit({
         type: 'success',

--- a/tests/dashboards/dashboard-management.spec.ts
+++ b/tests/dashboards/dashboard-management.spec.ts
@@ -27,22 +27,13 @@ test('as a user, I can create, update, and delete my dashboard', async ({
 
   await createDashboardPage.createButton.click();
 
-  await dashboardsPage.expectIsCurrentPage();
+  await expect(page).toHaveURL(/dashboards\/[a-zA-Z0-9_-]{12}/);
   await createDashboardPage.expectIsNotCurrentPage();
 
   await expect(application.notification).toBeVisible();
   await expect(application.notification).toContainText(
     'Successfully created dashboard "My Dashboard".',
   );
-
-  const dashboardRow = dashboardsTable.getRow({
-    name: 'My dashboard',
-    description: 'My dashboard description',
-  });
-  await expect(dashboardRow).toBeVisible();
-
-  await page.getByRole('link', { name: /[a-zA-Z0-9_-]{12}/ }).click();
-  await expect(page).toHaveURL(/dashboards\/[a-zA-Z0-9_-]{12}/);
 
   // check if viewport setting persists
   await page.getByRole('button', { name: 'Time machine' }).click();
@@ -62,6 +53,11 @@ test('as a user, I can create, update, and delete my dashboard', async ({
   );
 
   await dashboardsPage.goto();
+
+  const dashboardRow = dashboardsTable.getRow({
+    name: 'My dashboard',
+    description: 'My dashboard description',
+  });
 
   await expect(dashboardRow).toBeVisible();
   await expect(dashboardsPage.deleteButton).toBeDisabled();


### PR DESCRIPTION
# Description

## UX update to navigate to dashboard details page after creation (previously dashboards index page)

### Why

- this change removes the friction to go into the dashboard after the creation
- the newly created dashboard might not be present on the index page immediately after creation 
  - more details: the index page calls [DashboardsRepository.findAll(...)](https://github.com/awslabs/iot-application/blob/main/apps/core/src/dashboards/dashboards.repository.ts#L133-L139) and the secondary index Query cannot guarantee consistency

## Split deployment into deploy and test jobs

### Why

- to allow jobs to rerun independently
- to avoid playwright crashes due to memory constraint ([example](https://github.com/awslabs/iot-application/actions/runs/5029648649/jobs/9021498164))
  - [Linux VM with a limited 7 GB of RAM](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
