### PR TITLE
chore: IP rate limit WAF rule for Core

### DIFF
--- a/aws-resources-cfn-template.yaml
+++ b/aws-resources-cfn-template.yaml
@@ -171,6 +171,36 @@ Resources:
                   - !GetAtt ApiResourceTable.Arn
                   - !Sub ${ApiResourceTable.Arn}/index/*
 
+  CoreServiceWebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      DefaultAction:
+        Allow: {}
+      Rules:
+        - Action:
+            Block: {}
+          Name: IoTAppCoreServiceRateLimit
+          Priority: 0
+          Statement:
+            RateBasedStatement:
+              AggregateKeyType: "IP"
+              Limit: 3000  # 10 TPS over 5 minutes
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: IoTAppCoreServiceRateLimit
+            SampledRequestsEnabled: true
+      Scope: REGIONAL
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: IoTAppCoreServiceWebACL
+        SampledRequestsEnabled: true
+
+  CoreServiceWebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !GetAtt CoreService.ServiceArn
+      WebACLArn: !GetAtt CoreServiceWebACL.Arn
+
   AssetBucket:
     Type: "AWS::S3::Bucket"
     UpdateReplacePolicy: Retain
@@ -217,7 +247,7 @@ Resources:
     Type: 'AWS::CloudFront::ResponseHeadersPolicy'
     Properties:
       ResponseHeadersPolicyConfig:
-        Name: IoTApplicationPublicAssetHeaders
+        Name: IoTAppPublicAssetHeaders
         SecurityHeadersConfig:
           ContentSecurityPolicy:
             ContentSecurityPolicy: !Join

--- a/cdk/lib/core/core-service-web-acl.ts
+++ b/cdk/lib/core/core-service-web-acl.ts
@@ -1,0 +1,45 @@
+import { CfnWebACL, CfnWebACLAssociation } from 'aws-cdk-lib/aws-wafv2';
+import { Construct } from 'constructs';
+
+export class CoreServiceWebACL extends Construct {
+  readonly webACL: CfnWebACL;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    this.webACL = new CfnWebACL(this, 'WebACL', {
+      defaultAction: { allow: {} },
+      scope: 'REGIONAL',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: false,
+        metricName: 'IoTAppCoreServiceWebACL',
+        sampledRequestsEnabled: true,
+      },
+      rules: [
+        {
+          action: { block: {} },
+          name: 'IoTAppCoreServiceRateLimit',
+          priority: 0,
+          statement: {
+            rateBasedStatement: {
+              aggregateKeyType: 'IP',
+              limit: 3000, // 10 TPS over 5 minutes
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'IoTAppCoreServiceRateLimit',
+            sampledRequestsEnabled: true,
+          },
+        },
+      ],
+    });
+  }
+
+  public associate(resourceArn: string) {
+    new CfnWebACLAssociation(this, 'WebACLAssociation', {
+      resourceArn,
+      webAclArn: this.webACL.attrArn,
+    });
+  }
+}

--- a/cdk/lib/core/core-service.ts
+++ b/cdk/lib/core/core-service.ts
@@ -17,7 +17,7 @@ export interface CoreServiceProps {
 }
 
 export class CoreService extends Construct {
-  readonly serviceUrl: string;
+  readonly service: CfnService;
 
   constructor(scope: Construct, id: string, props: CoreServiceProps) {
     super(scope, id);
@@ -65,7 +65,7 @@ export class CoreService extends Construct {
       directory: path.join(__dirname, '../../..'),
     });
 
-    const service = new CfnService(this, 'Service', {
+    this.service = new CfnService(this, 'Service', {
       sourceConfiguration: {
         authenticationConfiguration: {
           accessRoleArn: serviceSourceRole.roleArn,
@@ -101,7 +101,5 @@ export class CoreService extends Construct {
         instanceRoleArn: serviceInstanceRole.roleArn,
       },
     });
-
-    this.serviceUrl = service.attrServiceUrl;
   }
 }

--- a/cdk/lib/core/core-stack.ts
+++ b/cdk/lib/core/core-stack.ts
@@ -1,6 +1,7 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { CoreService, CoreServiceProps } from './core-service';
+import { CoreServiceWebACL } from './core-service-web-acl';
 
 export interface CoreStackProps extends StackProps {
   readonly coreServiceProps: CoreServiceProps;
@@ -13,5 +14,11 @@ export class CoreStack extends Stack {
     super(scope, id, props);
 
     this.coreService = new CoreService(this, 'Service', props.coreServiceProps);
+
+    const {
+      service: { attrServiceArn: coreServiceArn },
+    } = this.coreService;
+    const coreServiceWebACL = new CoreServiceWebACL(this, 'WebACL');
+    coreServiceWebACL.associate(coreServiceArn);
   }
 }

--- a/cdk/lib/iot-application-stack.ts
+++ b/cdk/lib/iot-application-stack.ts
@@ -20,7 +20,9 @@ export class IotApplicationStack extends Stack {
     } = new DatabaseStack(this, 'Database', props);
 
     const {
-      coreService: { serviceUrl: coreServiceUrl },
+      coreService: {
+        service: { attrServiceUrl: coreServiceUrl },
+      },
     } = new CoreStack(this, 'Core', {
       coreServiceProps: {
         databaseTableArn: tableArn,


### PR DESCRIPTION
# Description

Added a WAF rule to rate-limit traffic by IP for core service. The rate is at 3,000 over 5 minutes matching the NestJS rule ([code](https://github.com/awslabs/iot-application/blob/main/apps/core/src/app.module.ts#L19)). This addition protects the core service against DoS at a reasonable TPS.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- deployed and verified the rule
> Rate-limiting criteria
Request aggregation
Source IP address
Rate limit
3,000

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
