### PR TITLE
chore: secure http headers

### DIFF
--- a/aws-resources-cfn-template.yaml
+++ b/aws-resources-cfn-template.yaml
@@ -346,7 +346,7 @@ Resources:
             const { Body, Bucket, Key } = event.ResourceProperties;
 
             if (requestType === 'Create' || requestType === 'Update') {
-              s3.putObject({ Body, Bucket, Key }).promise()
+              s3.putObject({ ContentType: 'application/javascript', Body, Bucket, Key }).promise()
                 .then(() => cfnresponse.send(event, context, cfnresponse.SUCCESS))
                 .catch(err => {
                   console.err(err)

--- a/aws-resources-cfn-template.yaml
+++ b/aws-resources-cfn-template.yaml
@@ -248,6 +248,11 @@ Resources:
     Properties:
       ResponseHeadersPolicyConfig:
         Name: IoTAppPublicAssetHeaders
+        CustomHeadersConfig:
+          Items:
+          - Header: Cache-Control
+            Override: true
+            Value: no-store
         SecurityHeadersConfig:
           ContentSecurityPolicy:
             ContentSecurityPolicy: !Join
@@ -266,6 +271,15 @@ Resources:
                 - script-src 'self' 'unsafe-eval';
                 - style-src 'self' 'unsafe-inline';
                 - upgrade-insecure-requests;
+            Override: true
+          ContentTypeOptions:
+            Override: true
+          FrameOptions:
+            FrameOption: DENY
+            Override: true
+          StrictTransportSecurity:
+            AccessControlMaxAgeSec: 47304000
+            IncludeSubdomains: true
             Override: true
 
   PublicAssetDistribution:

--- a/cdk/lib/asset/public-asset-stack.ts
+++ b/cdk/lib/asset/public-asset-stack.ts
@@ -1,6 +1,7 @@
 import { Duration, Stack, StackProps } from 'aws-cdk-lib';
 import {
   Distribution,
+  HeadersFrameOption,
   OriginAccessIdentity,
   ResponseHeadersPolicy,
   SecurityPolicyProtocol,
@@ -122,6 +123,27 @@ export class PublicAssetStack extends Stack {
             ),
             override: true,
           },
+          contentTypeOptions: {
+            override: true,
+          },
+          frameOptions: {
+            frameOption: HeadersFrameOption.DENY,
+            override: true,
+          },
+          strictTransportSecurity: {
+            accessControlMaxAge: Duration.seconds(47304000),
+            includeSubdomains: true,
+            override: true,
+          },
+        },
+        customHeadersBehavior: {
+          customHeaders: [
+            {
+              header: 'Cache-Control',
+              override: true,
+              value: 'no-store',
+            },
+          ],
         },
       },
     );

--- a/cdk/lib/asset/public-asset-stack.ts
+++ b/cdk/lib/asset/public-asset-stack.ts
@@ -75,6 +75,7 @@ export class PublicAssetStack extends Stack {
         destinationBucket: assetBucket,
         destinationKeyPrefix: assetHashKey,
         exclude: ['aws-resources.js'],
+        memoryLimit: 200,
         prune: false,
         sources: [Source.asset(path.join(__dirname, CLIENT_BUILD_DIR_PATH))],
       },
@@ -102,6 +103,7 @@ export class PublicAssetStack extends Stack {
           Body: `window.awsResources=${this.toJsonString(awsResources)};`,
           Bucket: assetBucket.bucketName,
           Key: `${assetHashKey}/aws-resources.js`,
+          ContentType: 'application/javascript',
         },
         // Update physical id to always overwrite
         physicalResourceId: PhysicalResourceId.of(Date.now().toString()),


### PR DESCRIPTION
# Description

The following HTTP headers are returned with each request to the client:
- X-Frame-Options: DENY
- X-Content-Type-Options: nosniff
- strict-transport-security: max-age=47304000; includeSubDomains
- Cache-Control: no-store

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- confirmed under Chrome DevTools

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
