### PR TITLE
chore: remove unsafe-eval from script-src CSP

### DIFF
--- a/aws-resources-cfn-template.yaml
+++ b/aws-resources-cfn-template.yaml
@@ -268,7 +268,7 @@ Resources:
                 - default-src 'none';
                 - font-src 'self' data:;
                 - img-src 'self' data:;
-                - script-src 'self' 'unsafe-eval';
+                - script-src 'self';
                 - style-src 'self' 'unsafe-inline';
                 - upgrade-insecure-requests;
             Override: true

--- a/cdk/lib/csp/public-asset-directives.ts
+++ b/cdk/lib/csp/public-asset-directives.ts
@@ -41,8 +41,7 @@ export function getImgSrcDirective(): string {
 }
 
 export function getScriptSrcDirective(): string {
-  // FIXME: 'unsafe-eval' source to be removed after removal of NPM dependency box-intersect
-  return "script-src 'self' 'unsafe-eval';";
+  return "script-src 'self';";
 }
 
 export function getStyleSrcDirective(): string {


### PR DESCRIPTION
# Description

'unsafe-eval' source can be removed after removal of NPM dependency box-intersect

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- verified updated script-src `content-security-policy: ... script-src 'self'; ...`
- no indication of scripts failing to execute.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
