### PR TITLE
chore: github action to build and push core service image to ECR Public Repo

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -1,0 +1,44 @@
+name: Distribution
+
+run-name: Distribution action initiated by ${{ github.actor }}
+
+on: workflow_dispatch
+
+# Ensures that only one deployment is in progress
+concurrency: ${{ github.workflow }}
+
+jobs:
+  core-distribution:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed to interact with GitHub's OIDC Token endpoint
+
+    # Reference: https://github.com/aws-actions/amazon-ecr-login#login-to-amazon-ecr-public-then-build-and-push-a-docker-image
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Configure AWS credentials 🔑
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.DISTRIBUTION_AWS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public 
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+
+      - name: Build, tag, and push docker image to Amazon ECR Public
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: ${{ secrets.DISTRIBUTION_REGISTRY_ALIAS }}
+          REPOSITORY: core-service
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
# Description

GitHub action to build and push core service image to ECR Public Repo. Image pushed to the ECR Public Repo can be consumed as the Core service image.

Note:
- Public Repo: https://gallery.ecr.aws/e1e5s5e0/core-service
- This is a step toward the distribution story. The next step is to build the CFN template to reference to the pushed Core service image and test against it.
- Triggers on manual dispatch (`on: workflow_dispatch`) for now. To be updated to trigger based on event when the workflow is complete.
- The secrets `DISTRIBUTION_AWS_ROLE` and `DISTRIBUTION_REGISTRY_ALIAS` were added manually.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Experimental run succeeded https://github.com/awslabs/iot-application/actions/runs/5484389190/workflow
- [x] Deployed with the Image and was operational

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
