### PR TITLE
chore: CodePipeline source S3 bucket regionalization

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -8,8 +8,8 @@ on: workflow_dispatch
 concurrency: ${{ github.workflow }}
 
 jobs:
-  core-distribution:
-    timeout-minutes: 60
+  core:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
@@ -33,24 +33,64 @@ jobs:
         with:
           registry-type: public
 
-      - name: Build, tag, and push docker image to Amazon ECR Public
+      - name: Build and push Core docker image to Amazon ECR Public
         env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY: public.ecr.aws
           REGISTRY_ALIAS: ${{ secrets.DISTRIBUTION_REGISTRY_ALIAS }}
           REPOSITORY: core-service
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
-          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-      
-      - name: Update and upload CloudFormation template to S3
+          CORE_IMAGE=$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+          docker build -t $CORE_IMAGE .
+          docker push $CORE_IMAGE
+  
+  cfn:
+    needs: core
+    strategy:
+      matrix:
+        include:
+          - region: us-east-2
+          - region: us-east-1
+          - region: us-west-2
+          - region: ap-south-1
+          - region: ap-northeast-2
+          - region: ap-southeast-1
+          - region: ap-southeast-2
+          - region: ap-northeast-1
+          - region: ca-central-1
+          - region: eu-central-1
+          - region: eu-west-1
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed to interact with GitHub's OIDC Token endpoint
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3 
+        with:
+          fetch-depth: 2
+
+      - name: Configure AWS credentials 🔑
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.DISTRIBUTION_AWS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Update CloudFormation template 📄
         env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY: public.ecr.aws
           REGISTRY_ALIAS: ${{ secrets.DISTRIBUTION_REGISTRY_ALIAS }}
           REPOSITORY: core-service
           IMAGE_TAG: ${{ github.sha }}
+        run: |
+          CORE_IMAGE=$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+          node cfn-with-core-image.js $CORE_IMAGE
+
+      - name: Upload CloudFormation template to S3 📁
+        env:
+          REGION: ${{ matrix.region }}
           S3_BUCKET: ${{ secrets.DISTRIBUTION_S3_BUCKET }}
         run: |
-          node cfn-with-core-image.js $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           zip -r cfn-template.zip ./cfn-template-with-core-tag.json
-          aws s3api put-object --bucket $S3_BUCKET --key cfn-template.zip --body ./cfn-template.zip
+          aws s3api put-object --bucket $S3_BUCKET-$REGION --key cfn-template.zip --body ./cfn-template.zip --region $REGION

--- a/cfn-template.json
+++ b/cfn-template.json
@@ -419,7 +419,9 @@
                 },
                 "Configuration": {
                   "PollForSourceChanges": "true",
-                  "S3Bucket": "aws-iot-application-distribution",
+                  "S3Bucket": {
+                    "Fn::Sub": "aws-iot-application-distribution-${AWS::Region}"
+                  },
                   "S3ObjectKey": "cfn-template.zip"
                 },
                 "OutputArtifacts": [
@@ -498,13 +500,17 @@
                     "s3:GetObject",
                     "s3:GetObjectVersion"
                   ],
-                  "Resource": "arn:aws:s3:::aws-iot-application-distribution/*"
+                  "Resource": {
+                    "Fn::Sub": "arn:aws:s3:::aws-iot-application-distribution-${AWS::Region}/*"
+                  }
                 },
                 {
                   "Sid": "AllowsSourceBucketAccess",
                   "Effect": "Allow",
                   "Action": "s3:GetBucketVersioning",
-                  "Resource": "arn:aws:s3:::aws-iot-application-distribution"
+                  "Resource": {
+                    "Fn::Sub": "arn:aws:s3:::aws-iot-application-distribution-${AWS::Region}"
+                  }
                 },
                 {
                   "Sid": "AllowsOutputBucketAccess",


### PR DESCRIPTION
# Description

There's a problem in the current [auto-update](https://github.com/awslabs/iot-application/pull/964) logic where it works in us-east-1 only. The CodePipeline S3 source is tracking an us-east-1 S3 bucket in all regions; however, the tracking does not work cross region and any regions outside of us-east-1 cannot be updated.

This PR adds regionalization support to the [auto-update](https://github.com/awslabs/iot-application/pull/964). There's an S3 bucket created in each of the supported regions for CodePipeline S3 source tracking purpose.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Used new CloudFormation template to deploy and auto-updated application, [previous run](https://github.com/awslabs/iot-application/actions/runs/5794474154/job/15704380745?pr=965)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
