### PR TITLE
fix: removed matchers test to fix unit test cases failing issue

### DIFF
--- a/apps/client/src/test/setup.ts
+++ b/apps/client/src/test/setup.ts
@@ -1,9 +1,6 @@
 import '@testing-library/jest-dom';
-import { expect, afterEach } from 'vitest';
+import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
-import matchers from '@testing-library/jest-dom/matchers';
-
-expect.extend(matchers);
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
# Description

Removed the matchers import from '@testing-library/jest-dom/matchers' since it caused all test cases fail. Refer below screenshot for reference.

![image](https://github.com/awslabs/iot-application/assets/139960352/80b55917-5ad0-475a-a9e4-510b39b7163c)

