### PR TITLE
feat: add left navigation and updated blue header as per 1100, 1101, 1111

### DIFF
--- a/apps/client/src/layout/components/side-navigation-panel/index.ts
+++ b/apps/client/src/layout/components/side-navigation-panel/index.ts
@@ -1,0 +1,1 @@
+export { SideNavigationPanel } from './side-navigation-panel';

--- a/apps/client/src/layout/components/side-navigation-panel/side-navigation-panel.spec.tsx
+++ b/apps/client/src/layout/components/side-navigation-panel/side-navigation-panel.spec.tsx
@@ -1,0 +1,25 @@
+import { vi } from 'vitest';
+import { render, screen } from '~/helpers/tests/testing-library';
+
+import { SideNavigationPanel } from './side-navigation-panel';
+
+describe('<SideNavigationPanel />', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should render the side navigation panel with Centurion Home in the header', () => {
+    render(<SideNavigationPanel />);
+
+    const centurionHomeText = screen.getByText('Centurion Home');
+
+    expect(centurionHomeText).toBeInTheDocument();
+  });
+  it('should render the side navigation panel with Dashboard link', () => {
+    render(<SideNavigationPanel />);
+
+    const dashboardsText = screen.getByText('Dashboards');
+
+    expect(dashboardsText).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/layout/components/side-navigation-panel/side-navigation-panel.tsx
+++ b/apps/client/src/layout/components/side-navigation-panel/side-navigation-panel.tsx
@@ -1,0 +1,74 @@
+import {
+  Badge,
+  SideNavigation,
+  SideNavigationProps,
+} from '@cloudscape-design/components';
+import { useIntl } from 'react-intl';
+
+import { DASHBOARDS_HREF } from '~/constants';
+
+export const SideNavigationPanel = () => {
+  const intl = useIntl();
+
+  const header: SideNavigationProps['header'] = {
+    text: intl.formatMessage({
+      defaultMessage: 'Centurion Home',
+      description: 'Centurion Home link',
+    }),
+    href: DASHBOARDS_HREF,
+  };
+
+  const items: SideNavigationProps['items'] = [
+    {
+      type: 'link',
+      text: intl.formatMessage({
+        defaultMessage: 'Dashboards',
+        description: 'Dashboard link',
+      }),
+      href: DASHBOARDS_HREF,
+    },
+    {
+      type: 'link',
+      text: intl.formatMessage({
+        defaultMessage: 'Templating',
+        description: 'Templating link',
+      }),
+      href: '#/templating',
+    },
+    {
+      type: 'link',
+      text: intl.formatMessage({
+        defaultMessage: "What's new",
+        description: "What's new link",
+      }),
+      href: '#/whatsnew',
+    },
+    { type: 'divider' },
+    {
+      type: 'link',
+      text: intl.formatMessage({
+        defaultMessage: 'Notifications',
+        description: 'Notifications link',
+      }),
+      href: '#/notifications',
+      info: <Badge color="red">22</Badge>,
+    },
+    {
+      type: 'link',
+      text: intl.formatMessage({
+        defaultMessage: 'Documentation',
+        description: 'Documentation link',
+      }),
+      href: '#/documentation',
+      external: true,
+    },
+  ];
+
+  return (
+    <SideNavigation
+      items={items}
+      header={header}
+      activeHref={DASHBOARDS_HREF}
+    />
+  );
+};

--- a/apps/client/src/layout/layout.tsx
+++ b/apps/client/src/layout/layout.tsx
@@ -1,9 +1,14 @@
-import AppLayout from '@cloudscape-design/components/app-layout';
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
+import AppLayout from '@cloudscape-design/components/app-layout';
+
+import { DASHBOARDS_HREF } from '~/constants';
 
 import { Breadcrumbs } from './components/breadcrumbs';
 import { Notifications } from './components/notifications';
 import { TopNavigation } from './components/top-navigation';
+import { SideNavigationPanel } from './components/side-navigation-panel';
 
 import { useFormat } from './hooks/use-format';
 import { useFullWidth } from './hooks/use-full-width';
@@ -13,21 +18,27 @@ export function Layout(props: React.PropsWithChildren) {
   const intl = useIntl();
   const format = useFormat();
   const fullWidth = useFullWidth();
+  const { pathname } = useLocation();
+
+  const isDashboard = pathname === DASHBOARDS_HREF;
+
+  const [isSideNavCollapsed, setIsSideNavCollapsed] = useState(false);
 
   return (
     <>
       <TopNavigation />
       <AppLayout
-        breadcrumbs={<Breadcrumbs />}
+        breadcrumbs={!isDashboard ? <Breadcrumbs /> : null}
         headerSelector="#h"
+        navigationOpen={isSideNavCollapsed}
+        onNavigationChange={() => {
+          setIsSideNavCollapsed(!isSideNavCollapsed);
+        }}
+        navigation={<SideNavigationPanel />}
         content={props.children}
         contentType={format}
         disableContentPaddings={fullWidth}
         notifications={<Notifications />}
-        // hide side navigation panel entirely
-        navigationHide={true}
-        // hide help panel entirely
-        toolsHide={true}
         ariaLabels={{
           navigation: intl.formatMessage({
             defaultMessage: 'Navigation drawer',

--- a/apps/client/src/routes/dashboards/create/create-dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/create/create-dashboard-page.tsx
@@ -11,6 +11,7 @@ import { DashboardDescriptionField } from './components/dashboard-description-fi
 import { useCreateDashboardForm } from './hooks/use-create-dashboard-form';
 import { useCreateDashboardMutation } from './hooks/use-create-dashboard-mutation';
 import { isNotFatal } from '~/helpers/predicates/is-not-fatal';
+import { Box, ContentLayout } from '@cloudscape-design/components';
 
 export function CreateDashboardPage() {
   const createDashboardMutation = useCreateDashboardMutation();
@@ -23,7 +24,20 @@ export function CreateDashboardPage() {
   }
 
   return (
-    <>
+    <ContentLayout
+      header={
+        <Box padding={{ top: 'xs' }}>
+          <SpaceBetween size="m">
+            <Header variant="h1">
+              <FormattedMessage
+                defaultMessage="Create Dashboard"
+                description="create dashboard heading"
+              />
+            </Header>
+          </SpaceBetween>
+        </Box>
+      }
+    >
       <form
         onSubmit={(event) => {
           event.preventDefault();
@@ -35,14 +49,6 @@ export function CreateDashboardPage() {
       >
         <Form
           variant="full-page"
-          header={
-            <Header variant="h1">
-              <FormattedMessage
-                defaultMessage="Create dashboard"
-                description="create dashboard heading"
-              />
-            </Header>
-          }
           actions={
             <CreateDashboardFormActions
               isLoading={createDashboardMutation.isLoading}
@@ -60,6 +66,6 @@ export function CreateDashboardPage() {
       </form>
 
       <DevTool control={control} />
-    </>
+    </ContentLayout>
   );
 }

--- a/apps/client/src/routes/dashboards/create/create-dashboard-route.tsx
+++ b/apps/client/src/routes/dashboards/create/create-dashboard-route.tsx
@@ -11,7 +11,7 @@ export const createDashboardRoute = {
   handle: {
     crumb: () => ({
       text: intl.formatMessage({
-        defaultMessage: 'Create',
+        defaultMessage: 'Create dashboard',
         description: 'create dashboard route breadcrumb text',
       }),
       href: CREATE_DASHBOARD_HREF,

--- a/apps/client/src/routes/dashboards/dashboards-index/components/getting-started.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/getting-started.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   ColumnLayout,
-  ContentLayout,
   ExpandableSection,
   Link,
   SpaceBetween,
@@ -103,54 +102,52 @@ const GettingStarted = () => {
   };
 
   return (
-    <ContentLayout>
-      <ExpandableSection
-        defaultExpanded
-        variant="container"
-        headerText={
+    <ExpandableSection
+      defaultExpanded
+      variant="container"
+      headerText={
+        <FormattedMessage
+          defaultMessage="Getting started"
+          description="Getting started title"
+        />
+      }
+      headerInfo={
+        <Link variant="info">
+          <FormattedMessage defaultMessage="Info" description="Info link" />
+        </Link>
+      }
+      headerActions={
+        <Button onClick={handleWhatsNew}>
           <FormattedMessage
-            defaultMessage="Getting started"
-            description="Getting started title"
+            defaultMessage="What's new"
+            description="What's new button title"
           />
-        }
-        headerInfo={
-          <Link variant="info">
-            <FormattedMessage defaultMessage="Info" description="Info link" />
-          </Link>
-        }
-        headerActions={
-          <Button onClick={handleWhatsNew}>
-            <FormattedMessage
-              defaultMessage="What's new"
-              description="What's new button title"
-            />
-          </Button>
-        }
-      >
-        <ColumnLayout columns={3} variant="text-grid">
-          {gettingStartedColumnArray.map((col, idx) => (
-            <SpaceBetween size="l" key={`${col.columnTitle}-${idx}`}>
-              <Box textAlign="center">
-                <div className={col.className}>
-                  <img src={col.icon} alt={col.buttonTitle} />
-                </div>
-              </Box>
-              <ValueWithLabel label={col.columnTitle}>
-                {col.columnDescription}
-              </ValueWithLabel>
-              <div className="getting-started-col-btn">
-                <Button
-                  data-testid={`getting-started-${col.buttonTitle}`}
-                  onClick={col.handleCallback}
-                >
-                  {col.buttonTitle}
-                </Button>
+        </Button>
+      }
+    >
+      <ColumnLayout columns={3} variant="text-grid">
+        {gettingStartedColumnArray.map((col, idx) => (
+          <SpaceBetween size="l" key={`${col.columnTitle}-${idx}`}>
+            <Box textAlign="center">
+              <div className={col.className}>
+                <img src={col.icon} alt={col.buttonTitle} />
               </div>
-            </SpaceBetween>
-          ))}
-        </ColumnLayout>
-      </ExpandableSection>
-    </ContentLayout>
+            </Box>
+            <ValueWithLabel label={col.columnTitle}>
+              {col.columnDescription}
+            </ValueWithLabel>
+            <div className="getting-started-col-btn">
+              <Button
+                data-testid={`getting-started-${col.buttonTitle}`}
+                onClick={col.handleCallback}
+              >
+                {col.buttonTitle}
+              </Button>
+            </div>
+          </SpaceBetween>
+        ))}
+      </ColumnLayout>
+    </ExpandableSection>
   );
 };
 

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
@@ -139,6 +139,14 @@ describe('<DashboardsIndexPage />', () => {
   });
 
   describe('header', () => {
+    it('should render the Centurion Home text on dashboard page', () => {
+      render(<DashboardsIndexPage />);
+
+      const centurionHomeText = screen.getByText('Centurion Home');
+
+      expect(centurionHomeText).toBeInTheDocument();
+    });
+
     it('should open the delete dashboard modal when delete button is clicked', async () => {
       const user = userEvent.setup();
       render(<DashboardsIndexPage />);

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -11,6 +11,7 @@ import Table from '@cloudscape-design/components/table';
 import { colorBackgroundHomeHeader } from '@cloudscape-design/design-tokens';
 import { BaseNavigationDetail } from '@cloudscape-design/components/internal/events';
 import { Box } from '@cloudscape-design/components';
+import ContentLayout from '@cloudscape-design/components/content-layout';
 import { DevTool } from '@hookform/devtools';
 import { useForm, Controller } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
@@ -122,8 +123,31 @@ export function DashboardsIndexPage() {
   };
 
   return (
-    <>
-      <Box padding={{ top: 'l' }}>
+    <ContentLayout
+      header={
+        <Box padding={{ top: 'xs' }}>
+          <SpaceBetween size="m">
+            <Header
+              variant="h1"
+              info={
+                <Link>
+                  <FormattedMessage
+                    defaultMessage="Info"
+                    description="info link"
+                  />
+                </Link>
+              }
+            >
+              <FormattedMessage
+                defaultMessage="Centurion Home"
+                description="centurion home heading"
+              />
+            </Header>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <Box>
         <GettingStarted />
       </Box>
       <Box padding={{ top: 'l' }}>
@@ -629,6 +653,6 @@ export function DashboardsIndexPage() {
       />
 
       <DevTool control={control} />
-    </>
+    </ContentLayout>
   );
 }

--- a/apps/client/src/routes/dashboards/root-dashboards/root-dashboards-route.tsx
+++ b/apps/client/src/routes/dashboards/root-dashboards/root-dashboards-route.tsx
@@ -3,7 +3,6 @@ import { dashboardsIndexRoute } from '../dashboards-index';
 import { dashboardRoute } from '../dashboard';
 import { createDashboardRoute } from '../create';
 import { DASHBOARDS_PATH, DASHBOARDS_HREF } from '~/constants';
-import { intl } from '~/services';
 
 import type { RouteObject } from 'react-router-dom';
 
@@ -12,13 +11,6 @@ export const rootDashboardsRoute = {
   element: <RootDashboardsPage />,
   handle: {
     activeHref: DASHBOARDS_HREF,
-    crumb: () => ({
-      text: intl.formatMessage({
-        defaultMessage: 'Dashboards',
-        description: 'dashboards route breadcrumb text',
-      }),
-      href: DASHBOARDS_HREF,
-    }),
   },
   children: [dashboardsIndexRoute, dashboardRoute, createDashboardRoute],
 } satisfies RouteObject;

--- a/apps/client/src/routes/root/root-route.tsx
+++ b/apps/client/src/routes/root/root-route.tsx
@@ -24,7 +24,7 @@ export const rootRoute = {
     activeHref: ROOT_HREF,
     crumb: () => ({
       text: intl.formatMessage({
-        defaultMessage: 'IoT Application',
+        defaultMessage: 'Centurion Home',
         description: 'root route breadcrumb text',
       }),
       href: ROOT_HREF,


### PR DESCRIPTION
# Description

- Added left-side navigation panel. 
- Removed breadcrumb in the dashboard page.
- Added Centurion page title and also added respective page titles for each page.
- Added Breadcrumb in other than the dashboard screen.
- Added a help section on the right side of the blue header.

![image](https://github.com/awslabs/iot-application/assets/139960352/9ca36951-a2f5-414a-8710-77258da2ebd5)

![image](https://github.com/awslabs/iot-application/assets/139960352/a1c3403e-9401-46c3-a9ab-278e6760a2fd)

![image](https://github.com/awslabs/iot-application/assets/139960352/41143571-0aa3-4b60-b29e-39ba5458ae0e)



This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
