### PR TITLE
feat: update create dashboard page

### DIFF
--- a/apps/client/src/routes/dashboards/create/components/create-dashboard-form-actions.tsx
+++ b/apps/client/src/routes/dashboards/create/components/create-dashboard-form-actions.tsx
@@ -1,5 +1,6 @@
 import Button from '@cloudscape-design/components/button';
 import SpaceBetween from '@cloudscape-design/components/space-between';
+import { colorBackgroundHomeHeader } from '@cloudscape-design/design-tokens';
 import { FormattedMessage } from 'react-intl';
 
 import { DASHBOARDS_HREF } from '~/constants';
@@ -16,18 +17,29 @@ export function CreateDashboardFormActions(
 
   return (
     <SpaceBetween direction="horizontal" size="xs">
-      <Button formAction="none" onClick={() => navigate(DASHBOARDS_HREF)}>
+      <Button
+        formAction="none"
+        variant="link"
+        onClick={() => navigate(DASHBOARDS_HREF)}
+      >
         <FormattedMessage
           defaultMessage="Cancel"
           description="create dashboard form cancel button"
         />
       </Button>
 
-      <Button variant="primary" loading={props.isLoading} formAction="submit">
-        <FormattedMessage
-          defaultMessage="Create"
-          description="create dashboard form confirm button"
-        />
+      <Button
+        variant="primary"
+        loading={props.isLoading}
+        formAction="submit"
+        className="btn-custom-primary"
+      >
+        <span style={{ color: colorBackgroundHomeHeader }}>
+          <FormattedMessage
+            defaultMessage="Create dashboard"
+            description="create dashboard form confirm button"
+          />
+        </span>
       </Button>
     </SpaceBetween>
   );

--- a/apps/client/src/routes/dashboards/create/components/dashboard-description-field.tsx
+++ b/apps/client/src/routes/dashboards/create/components/dashboard-description-field.tsx
@@ -8,6 +8,7 @@ import { $Dashboard } from '~/services';
 import type { Control } from 'react-hook-form';
 import { CreateDashboardFormValues } from '../types/create-dashboard-form-values';
 import { isJust } from '~/helpers/predicates/is-just';
+import { Link } from '@cloudscape-design/components';
 
 interface DashboardDescriptionFieldProps {
   control: Control<CreateDashboardFormValues>;
@@ -44,17 +45,13 @@ export function DashboardDescriptionField(
       render={({ field, fieldState }) => (
         <FormField
           label={intl.formatMessage({
-            defaultMessage: 'Dashboard description',
+            defaultMessage: 'Dashboard description - optional',
             description: 'create dashboard form description label',
           })}
-          description={intl.formatMessage({
-            defaultMessage: 'Enter the description for your dashboard.',
-            description: 'create dashboard form description description',
-          })}
+          info={<Link variant="info">Info</Link>}
           constraintText={intl.formatMessage(
             {
-              defaultMessage:
-                'Dashboard description must be between {minLength} and {maxLength} characters',
+              defaultMessage: 'Description must be fewer than 512 characters.',
               description: 'create dashboard form description constraint',
             },
             {
@@ -66,10 +63,6 @@ export function DashboardDescriptionField(
         >
           <Textarea
             ariaRequired
-            placeholder={intl.formatMessage({
-              defaultMessage: 'Dashboard description',
-              description: 'create dashboard form description placeholder',
-            })}
             onChange={(event) => field.onChange(event.detail.value)}
             value={field.value}
           />

--- a/apps/client/src/routes/dashboards/create/components/dashboard-name-field.tsx
+++ b/apps/client/src/routes/dashboards/create/components/dashboard-name-field.tsx
@@ -8,6 +8,7 @@ import { $Dashboard } from '~/services';
 import type { Control } from 'react-hook-form';
 import type { CreateDashboardFormValues } from '../types/create-dashboard-form-values';
 import { isJust } from '~/helpers/predicates/is-just';
+import { Link } from '@cloudscape-design/components';
 
 interface DashboardNameFieldProps {
   control: Control<CreateDashboardFormValues>;
@@ -43,14 +44,11 @@ export function DashboardNameField(props: DashboardNameFieldProps) {
             defaultMessage: 'Dashboard name',
             description: 'create dashboard form name label',
           })}
-          description={intl.formatMessage({
-            defaultMessage: 'Enter the name you want to give your dashboard.',
-            description: 'create dashboard form name description',
-          })}
+          info={<Link variant="info">Info</Link>}
           constraintText={intl.formatMessage(
             {
               defaultMessage:
-                'Dashboard name must be between {minLength} and {maxLength} characters',
+                'Name must be alphanumeric, unique and fewer than 63 characters, It can include hyphen(-) and spaces.',
               description: 'create dashboard form name constraint',
             },
             {
@@ -63,7 +61,7 @@ export function DashboardNameField(props: DashboardNameFieldProps) {
           <Input
             ariaRequired
             placeholder={intl.formatMessage({
-              defaultMessage: 'Dashboard name',
+              defaultMessage: 'dashboard name',
               description: 'create dashboard form name placeholder',
             })}
             onChange={(event) => field.onChange(event.detail.value)}

--- a/apps/client/src/routes/dashboards/create/create-dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/create/create-dashboard-page.tsx
@@ -56,7 +56,19 @@ export function CreateDashboardPage() {
           }
           errorText={getFormErrorText()}
         >
-          <Container>
+          <Container
+            header={
+              <Header
+                variant="h1"
+                description="Create a dashboard to monitor your assets and properties."
+              >
+                <FormattedMessage
+                  defaultMessage="General details"
+                  description="Create dashboard modal header"
+                />
+              </Header>
+            }
+          >
             <SpaceBetween size="l">
               <DashboardNameField control={control} />
               <DashboardDescriptionField control={control} />

--- a/tests/pages/create-dashboard.page.ts
+++ b/tests/pages/create-dashboard.page.ts
@@ -20,8 +20,10 @@ export class CreateDashboardPage {
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { name: 'Create dashboard' });
-    this.nameField = page.getByLabel('Dashboard name');
-    this.descriptionField = page.getByLabel('Dashboard description');
+    this.nameField = page.getByRole('textbox', { name: 'Dashboard name' });
+    this.descriptionField = page.getByRole('textbox', {
+      name: 'Dashboard description',
+    });
     this.createButton = page.getByRole('button', { name: 'Create' });
     this.cancelButton = page.getByRole('button', { name: 'Cancel' });
     this.nameRequiredError = page.getByText('Dashboard name is required.');


### PR DESCRIPTION
This PR is for the Dashboard table update. new changes include

1.  Updated the Text in the general details section and Name, description section
2.  added the two "info" tool tips
3. Updated the create dashboard and Cancel button as per design

New design:
![image](https://github.com/awslabs/iot-application/assets/142866907/35a41241-033e-48e5-bea0-0cd12c139798)


## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
