### PR TITLE
fix: bump AWS credentials action

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn workspace client build
 
       - name: Configure AWS credentials 🔑
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
           aws-region: us-west-2

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 2
 
       - name: Configure AWS credentials 🔑
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.DISTRIBUTION_AWS_ROLE }}
           aws-region: us-east-1
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 2
 
       - name: Configure AWS credentials 🔑
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.DISTRIBUTION_AWS_ROLE }}
           aws-region: us-east-1


### PR DESCRIPTION
# Description

All builds are failing with the error:
```
Run aws-actions/configure-aws-credentials@v2
(node:2142) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
