### PR TITLE
fix: downgrade configure-aws-credentials from v4 to v3 to fix credential failure in deployment

### DIFF
--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Configure AWS credentials 🔑
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
           aws-region: us-west-2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Configure AWS credentials 🔑
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
           aws-region: us-west-2

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 2
 
       - name: Configure AWS credentials 🔑
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.DISTRIBUTION_AWS_ROLE }}
           aws-region: us-east-1
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 2
 
       - name: Configure AWS credentials 🔑
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.DISTRIBUTION_AWS_ROLE }}
           aws-region: us-east-1


### PR DESCRIPTION
# Description

* deploy-pr action is failing with message `Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers`
* we previously added a permissions fix that should have resolved the issue: https://github.com/awslabs/iot-application/pull/1169
* dependabot recently upgraded `configure-aws-credentials` from `v3` to `v4` which uses `node20` instead of `node16` which appears to have broken the credential role fetching. Downgrading in this change to fix. I validated the fix works in a draft PR: https://github.com/awslabs/iot-application/pull/1287

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] deploy-pr action passes in draft pr

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
