### PR TITLE
fix: move dependabot failure check to be first step

### DIFF
--- a/.github/workflows/dependabot-hook.yml
+++ b/.github/workflows/dependabot-hook.yml
@@ -14,31 +14,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto_approve_pr:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-  auto_merge_pr:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Enable Auto-Merge for PR
-        run: gh pr merge --auto --rebase --delete-branch "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
   close_pr_if_required_checks_fail:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'failure' }}
 
     steps:
@@ -61,6 +39,30 @@ jobs:
       - name: Close PR if Required Checks Fail
         if: ${{ steps.failed_checks.outputs.close_pr == 'true' }}
         run: gh pr close "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  auto_approve_pr:
+    needs: close_pr_if_required_checks_fail
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  auto_merge_pr:
+    needs: close_pr_if_required_checks_fail
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable Auto-Merge for PR
+        run: gh pr merge --auto --rebase --delete-branch "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# Description

* Dependabot updates are getting auto-merged even when they break the deployment process: https://github.com/awslabs/iot-application/pull/1294. This is happening because the approve and merge steps happen before the failure check, so the failure check never gets run.
* This change moves the failure check to be first and increases the timeout to 30 min to allow enough time for the build and deployment to complete before auto approving and merging the PR. Added the `needs` parameter which will only run the approve and merge jobs once the failure check it successful.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Since this modifies the dependabot behaviour, once this PR is merged I will manually validate the next dependabot PR runs the failure check step first

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
