### PR TITLE
feat: update README with SSO integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Run `yarn gen:types` in root while `yarn dev` is running.
 
 This will deploy the application to AWS using CDK.
 
-##### Prerequisites:
+##### Cloud deployment prerequisites:
 
-1. Install docker: https://docs.docker.com/get-docker/
+1. [Configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) AWS CLI credentials for making AWS service calls to setup the application
+1. Install docker: https://docs.docker.com/get-docker/. Docker must be running when you run the deployment commands.
 1. For the initial deployment, bootstrap cdk in your account:
    ```sh
    yarn workspace cdk cdk bootstrap
@@ -59,6 +60,10 @@ This will deploy the application to AWS using CDK.
 
 ##### Deployment to cloud:
 
+Note: All commands should be run in the workspace root directory. We are using [yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/) to handle individual package commands.
+
+1. Complete the [prerequisites](https://github.com/awslabs/iot-application/blob/main/README.md#prerequisites)
+1. Add your AWS accountId and region [here](https://github.com/awslabs/iot-application/blob/main/cdk/bin/cdk.ts#L17) to setup the cdk envrionment.
 1. Install application dependencies:
    ```sh
    yarn install
@@ -67,12 +72,65 @@ This will deploy the application to AWS using CDK.
    ```sh
    yarn workspace cdk cdk deploy --all
    ```
+1. View your application resources in CloudFormation. If you go to the stack IotApp -> Outputs you can see the URL that the application will be available from.
 
 To specify a stack name, use the --context (-c) option, as shown in the following example.
 
 ```sh
 yarn workspace cdk cdk deploy -c stackName=my-stack-name
 ```
+
+## AWS IAM Identity Center (SSO) integration:
+If you wish to use IAM Identity Center as your authentication source, there are some manual steps to complete first.
+
+This integration is based on [these integration instructions](https://repost.aws/knowledge-center/cognito-user-pool-iam-integration).
+
+#### Gather information from Cloudformation
+Go to the CloudFormation console to get required resource information. You will need to take note of the following values: `domain-prefix`, `userpool-id`, `client-id` and `signin-url`. These will be used to configure IAM Identity Center as an authentication source.
+1. Find the stack called `IotApp`
+   * Go to the outputs tab and note down the value for `AppUrl` as the `signin-url` that will be used later.
+1. Find the stack called `IotAppAuth`
+   * Go to the resources tab and expand the Auth section.
+   * Note down the physical id value for `UserPoolDomain` as `domain-prefix`
+   * Note down the physical id value for `UserPool` as `userpool-id`
+   * Note down the physical id value for `UserPoolClient` as `client-id`
+#### Configure IAM Identity Center
+Configure an IAM Identity Center application to be used for authentication. Visit the IAM Identity Center console. Activate IAM Identity Center if it is not already setup.
+1. Go to applications
+1. Choose `Add application` and `Add custom SAML 2.0 application`.
+   * Enter a name and description
+1. Note down the URL of the `IAM Identity Center SAML metadatafile` as `metadata-url`
+1. Click next and assign any SSO users you want to be able to access this application
+1. Add environment information at bottom of page. Here you will need some of the values noted earlier.
+   * ACS URL = `https://<domain-prefix>.auth.<region>.amazoncognito.com/saml2/idpresponse`
+   * Application SAML audience = `urn:amazon:cognito:sp:<userpool-id>`
+1. Save changes
+1. Manually add metadata values
+   * From the application page you just created, go to actions &rarr; Edit attribute mapping
+   * Fill in subject value with `${user:subject}` and choose `Persistent`
+   * Add a new metadata field with values `email`, `${user:email}` and choose `Basic`
+   * Save changes
+#### Configure Cognito to use IAM Identity Center
+Configure your cognito identity pool for identity center integration.
+1. Configure user pool to use IAM Identity Center
+   * Go to the cognito console and find the userpool that was just created
+   * Go to sign-in experience &rarr; federated sign-in &rarr; add an identity provider
+   * Under metadata document, enter hte metadata URL you noted earlier
+   * Configure the SAML attriute mapping
+      * Choose email, and for `User pool attribute`, type `Email`
+   * Save changes
+1. Choose IAM Identity Center as the user pool auth source
+   * Go to the cognito console and find the userpool that was just created
+   * Under the `App Integration` tab, click on the app client in the `app client list` section
+   * Click `edit Hosted UI`
+   * Change the value of URL to `signin-url` we noted earlier
+   * Under the `Identity Proider`, select the IAM identity center application created earlier and uncheck cognito
+   * Save changes
+#### Sign in using IAM Identity Center for the application
+Log in using IAM Identity Center. This url is different from the original cognito sign-in url.
+   * Visit `https://<domain-prefix>.auth.<region>.amazoncognito.com/login?response_type=token&client_id=<client-id>&redirect_uri=<signin-url>` to sign in using IAM Identity Center as the authentication source for the application. The variables here are the same as the ones noted earlier from Cloudformation.
+
+User management is handled from the IAM Identity Center console.
 
 ## Environments
 


### PR DESCRIPTION
# Description

* Updating the deployment README to include the instructions on IAM Identity Center(SSO) integration with Cognito. These instructions are based on [these setup instructions](https://repost.aws/knowledge-center/cognito-user-pool-iam-integration).
* I had hoped to be able to add more SSO-setup resources to CDK, but SSO resources aren't available in CDK and any additional userpool setup steps must be completed after the SSO application is configured. For example, when creating the SSO application, we need the domainName, userPoolId and clientId so the application stack must already exist when creating the SSO application. Once the application is complete, the userpool must be updated with the metadata URL from the SSO application, so those steps must also be manual since we won't know the metadat url until the manual SSO application creation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] This change is a README update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Validated that the markdown renders correctly in VS Code.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
