### PR TITLE
fix: correct domain url in oath config

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Log in using IAM Identity Center. This url is different from the original cognit
 
 User management is handled from the IAM Identity Center console.
 
+#### Sign out
+1. Click the `sign-out` button in the application, you will be redirected to the IAM Identity Center applications page. 
+1. Click the signout button in the top right navigation of this page to complete signing out of the application.
+
 ## Environments
 
 ### Service Dependencies

--- a/apps/client/src/index.tsx
+++ b/apps/client/src/index.tsx
@@ -40,7 +40,7 @@ Amplify.configure({
     userPoolId,
     userPoolWebClientId,
     oauth: {
-      domain: domainName,
+      domain: `${domainName}.auth.${region}.amazoncognito.com`,
       scope: ['email', 'aws.cognito.signin.user.admin'],
       redirectSignIn: '', // config in cognito
       redirectSignOut: '', // config in cognito


### PR DESCRIPTION
# Description

* Right now, if you set up the SSO integration and click sign out, you will be redirected to an invalid url. This is because the domain prefix is being set as the domain url instead of the full domain.
* This change corrects this domain configuration in the amplify oauth config so the signout redirects to a valid url.
* There is one caveat to note which is that with this change when you click sign out in our application, it redirects to the sso application page where you must click sign out again to be fully signed out of SSO. I will follow up with a change to make it so only a single sign out click is needed, but for now this fixes the broken experience.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Deployed the application, set up SSO, and tested clicking sign out. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
