### PR TITLE
fix: support line-scatter-chart

### DIFF
--- a/apps/core/src/dashboards/dashboards.e2e.spec.ts
+++ b/apps/core/src/dashboards/dashboards.e2e.spec.ts
@@ -455,6 +455,7 @@ describe('DashboardsModule', () => {
     );
 
     test.each([
+      DashboardWidgetType.LineScatterChart,
       DashboardWidgetType.LineChart,
       DashboardWidgetType.ScatterChart,
       DashboardWidgetType.BarChart,
@@ -1092,6 +1093,7 @@ describe('DashboardsModule', () => {
     );
 
     test.each([
+      DashboardWidgetType.LineScatterChart,
       DashboardWidgetType.LineChart,
       DashboardWidgetType.ScatterChart,
       DashboardWidgetType.BarChart,

--- a/apps/core/src/dashboards/entities/dashboard-widget.entity.ts
+++ b/apps/core/src/dashboards/entities/dashboard-widget.entity.ts
@@ -4,6 +4,7 @@ import { IsEnum, IsInt, IsNumber, IsObject, IsString } from 'class-validator';
  * List of available widget types.
  */
 export enum DashboardWidgetType {
+  LineScatterChart = 'line-scatter-chart',
   LineChart = 'line-chart',
   ScatterChart = 'scatter-chart',
   BarChart = 'bar-chart',


### PR DESCRIPTION
# Description

The dashboard API was never updated to support the new line-scatter chart. Without this change, dashboards will throw 400s when attempting to save a dashboard with the line-scatter chart.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
