### PR TITLE
fix: add permissions for ListTimeSeries and ExecuteQuery APIs

### DIFF
--- a/cdk/lib/auth/auth-stack.ts
+++ b/cdk/lib/auth/auth-stack.ts
@@ -71,6 +71,7 @@ export class AuthStack extends Stack {
     authenticatedRole.addToPolicy(
       new PolicyStatement({
         actions: [
+	        'iottwinmaker:ExecuteQuery',
           'iotsitewise:DescribeAsset',
           'iotsitewise:ListAssets',
           'iotsitewise:ListAssociatedAssets',
@@ -84,6 +85,7 @@ export class AuthStack extends Stack {
           'iotsitewise:ListAssetRelationships',
           'iotsitewise:DescribeAssetModel',
           'iotsitewise:ListAssetModels',
+	        'iotsitewise:ListTimeSeries',
           'iotevents:DescribeAlarmModel',
           'iotevents:ListTagsForResource',
         ],


### PR DESCRIPTION
# Description

This change provides the necessary permissions to the application user to list unmodeled data streams and execute search requests.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
