### PR TITLE
feat: added a build button that takes user directly to edit mode #1281

### DIFF
--- a/apps/client/src/routes/dashboards/create/hooks/use-create-dashboard-mutation.tsx
+++ b/apps/client/src/routes/dashboards/create/hooks/use-create-dashboard-mutation.tsx
@@ -2,6 +2,7 @@ import Button from '@cloudscape-design/components/button';
 import { useMutation } from '@tanstack/react-query';
 import { useIntl, FormattedMessage } from 'react-intl';
 import invariant from 'tiny-invariant';
+import { useSetAtom } from 'jotai';
 
 import {
   cancelDashboardsQueries,
@@ -11,6 +12,7 @@ import {
 import { isApiError } from '~/helpers/predicates/is-api-error';
 import { isFatal } from '~/helpers/predicates/is-fatal';
 import { useEmitNotification } from '~/hooks/notifications/use-emit-notification';
+import { setDashboardEditMode } from '~/store/view-mode';
 import { useApplication } from '~/hooks/application/use-application';
 import { createDashboard } from '~/services';
 import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
@@ -19,6 +21,9 @@ import type { Dashboard } from '~/services';
 
 export function useCreateDashboardMutation() {
   const emit = useEmitNotification();
+
+  const emitEditMode = useSetAtom(setDashboardEditMode);
+
   const intl = useIntl();
   const { navigate } = useApplication();
 
@@ -35,6 +40,8 @@ export function useCreateDashboardMutation() {
       await prefetchDashboards();
 
       navigate(`/dashboards/${newDashboard.id}`);
+
+      emitEditMode(true);
 
       emit({
         type: 'success',

--- a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
@@ -5,6 +5,7 @@ import {
 import { Auth } from 'aws-amplify';
 import { useParams } from 'react-router-dom';
 import invariant from 'tiny-invariant';
+import { useAtomValue } from 'jotai';
 
 import { DashboardLoadingState } from './components/dashboard-loading-state';
 import { isJust } from '~/helpers/predicates/is-just';
@@ -15,8 +16,12 @@ import './styles.css';
 import type { DashboardDefinition } from '~/services';
 import { useViewport } from '~/hooks/dashboard/use-viewport';
 
+import { getDashboardEditMode } from '~/store/view-mode';
+
 export function DashboardPage() {
   const params = useParams<{ dashboardId: string }>();
+
+  const editMode = useAtomValue(getDashboardEditMode);
 
   invariant(
     isJust(params.dashboardId),
@@ -63,7 +68,7 @@ export function DashboardPage() {
         },
         viewport,
       }}
-      initialViewMode="preview"
+      initialViewMode={editMode ? 'edit' : 'preview'}
       onSave={(
         config: DashboardDefinition & Omit<DashboardConfiguration, 'widgets'>,
       ) => {

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
@@ -163,6 +163,21 @@ describe('<DashboardsIndexPage />', () => {
 
       expect(navigateMock).toHaveBeenCalledWith(CREATE_DASHBOARD_HREF);
     });
+
+    it('should navigate to edit dashboard page when the Build button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<DashboardsIndexPage />);
+
+      await user.click(
+        screen.getByRole('checkbox', { name: 'Select dashboard test name' }),
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Build' }));
+
+      expect(navigateMock).toHaveBeenCalledWith(
+        `/dashboards/${getDashboardStubs()[0].id}`,
+      );
+    });
   });
 
   describe('inline editing', () => {

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -230,65 +230,68 @@ export function DashboardsIndexPage() {
             </Header>
           }
           filter={
-            <PropertyFilter
-              {...propertyFilterProps}
-              countText={intl.formatMessage(
-                {
-                  defaultMessage: `
+            // no props available for this in cloudscape to show full width
+            <div className="dashboard-table-filter">
+              <PropertyFilter
+                {...propertyFilterProps}
+                countText={intl.formatMessage(
+                  {
+                    defaultMessage: `
                 {dashboardCount, plural,
                   zero {# matches}
                   one {# match}
                   other {# matches}}
                 `,
-                  description: 'dashboards table filter count text',
-                },
-                { dashboardCount: filteredItemsCount },
-              )}
-              filteringPlaceholder={intl.formatMessage({
-                defaultMessage: 'Find dashboards',
-                description: 'dashboards table filter placeholder',
-              })}
-              // TODO: internationalize fields
-              filteringLoadingText="Loading suggestions"
-              filteringErrorText="Error fetching suggestions."
-              filteringRecoveryText="Retry"
-              filteringFinishedText="End of results"
-              filteringEmpty="No suggestions found"
-              i18nStrings={{
-                filteringAriaLabel: 'your choice',
-                dismissAriaLabel: 'Dismiss',
-                filteringPlaceholder:
-                  'Filter assets by text, property or value',
-                groupValuesText: 'Values',
-                groupPropertiesText: 'Properties',
-                operatorsText: 'Operators',
-                operationAndText: 'and',
-                operationOrText: 'or',
-                operatorLessText: 'Less than',
-                operatorLessOrEqualText: 'Less than or equal',
-                operatorGreaterText: 'Greater than',
-                operatorGreaterOrEqualText: 'Greater than or equal',
-                operatorContainsText: 'Contains',
-                operatorDoesNotContainText: 'Does not contain',
-                operatorEqualsText: 'Equals',
-                operatorDoesNotEqualText: 'Does not equal',
-                editTokenHeader: 'Edit filter',
-                propertyText: 'Property',
-                operatorText: 'Operator',
-                valueText: 'Value',
-                cancelActionText: 'Cancel',
-                applyActionText: 'Apply',
-                allPropertiesLabel: 'All properties',
-                tokenLimitShowMore: 'Show more',
-                tokenLimitShowFewer: 'Show fewer',
-                clearFiltersText: 'Clear filters',
-                removeTokenButtonAriaLabel: (token) =>
-                  `Remove token ${token.propertyKey ?? '{token}'} ${
-                    token.operator
-                  } ${token.value as string}`,
-                enteredTextLabel: (text) => `Use: "${text}"`,
-              }}
-            />
+                    description: 'dashboards table filter count text',
+                  },
+                  { dashboardCount: filteredItemsCount },
+                )}
+                filteringPlaceholder={intl.formatMessage({
+                  defaultMessage: 'Find dashboards',
+                  description: 'dashboards table filter placeholder',
+                })}
+                // TODO: internationalize fields
+                filteringLoadingText="Loading suggestions"
+                filteringErrorText="Error fetching suggestions."
+                filteringRecoveryText="Retry"
+                filteringFinishedText="End of results"
+                filteringEmpty="No suggestions found"
+                i18nStrings={{
+                  filteringAriaLabel: 'your choice',
+                  dismissAriaLabel: 'Dismiss',
+                  filteringPlaceholder:
+                    'Filter assets by text, property or value',
+                  groupValuesText: 'Values',
+                  groupPropertiesText: 'Properties',
+                  operatorsText: 'Operators',
+                  operationAndText: 'and',
+                  operationOrText: 'or',
+                  operatorLessText: 'Less than',
+                  operatorLessOrEqualText: 'Less than or equal',
+                  operatorGreaterText: 'Greater than',
+                  operatorGreaterOrEqualText: 'Greater than or equal',
+                  operatorContainsText: 'Contains',
+                  operatorDoesNotContainText: 'Does not contain',
+                  operatorEqualsText: 'Equals',
+                  operatorDoesNotEqualText: 'Does not equal',
+                  editTokenHeader: 'Edit filter',
+                  propertyText: 'Property',
+                  operatorText: 'Operator',
+                  valueText: 'Value',
+                  cancelActionText: 'Cancel',
+                  applyActionText: 'Apply',
+                  allPropertiesLabel: 'All properties',
+                  tokenLimitShowMore: 'Show more',
+                  tokenLimitShowFewer: 'Show fewer',
+                  clearFiltersText: 'Clear filters',
+                  removeTokenButtonAriaLabel: (token) =>
+                    `Remove token ${token.propertyKey ?? '{token}'} ${
+                      token.operator
+                    } ${token.value as string}`,
+                  enteredTextLabel: (text) => `Use: "${text}"`,
+                }}
+              />
+            </div>
           }
           preferences={
             <CollectionPreferences

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -17,6 +17,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import type { FormatDateOptions } from 'react-intl';
 import invariant from 'tiny-invariant';
+import { useSetAtom } from 'jotai';
 
 import { CREATE_DASHBOARD_HREF } from '~/constants';
 import { DeleteDashboardModal } from './components/delete-dashboard-modal';
@@ -25,6 +26,7 @@ import GettingStarted from './components/getting-started';
 import { NoMatchDashboardsTable } from './components/no-matches-dashboards-table';
 import { isJust } from '~/helpers/predicates/is-just';
 import { useApplication } from '~/hooks/application/use-application';
+import { setDashboardEditMode } from '~/store/view-mode';
 import { useDashboardsQuery } from './hooks/use-dashboards-query';
 import { useDeleteModalVisibility } from './hooks/use-delete-modal-visibility';
 import { usePartialUpdateDashboardMutation } from './hooks/use-partial-update-dashboard-mutation';
@@ -43,6 +45,7 @@ const DateFormatOptions: FormatDateOptions = {
 };
 
 export function DashboardsIndexPage() {
+  const emitEditMode = useSetAtom(setDashboardEditMode);
   const intl = useIntl();
   const [isDeleteModalVisible, setIsDeleteModalVisible] =
     useDeleteModalVisibility();
@@ -110,6 +113,14 @@ export function DashboardsIndexPage() {
 
   const handleViewDashboard = (selected?: DashboardSummary) => {
     if (selected?.id) {
+      emitEditMode(false);
+      navigate(`/dashboards/${selected.id}`);
+    }
+  };
+
+  const handleEditDashboard = (selected?: DashboardSummary) => {
+    if (selected?.id) {
+      emitEditMode(true);
       navigate(`/dashboards/${selected.id}`);
     }
   };
@@ -118,7 +129,7 @@ export function DashboardsIndexPage() {
     event.preventDefault();
 
     invariant(isJust(event.detail.href), 'Expected href to be defined');
-
+    emitEditMode(false);
     navigate(event.detail.href);
   };
 
@@ -204,6 +215,16 @@ export function DashboardsIndexPage() {
                     <FormattedMessage
                       defaultMessage="View"
                       description="dashboards table header view button"
+                    />
+                  </Button>
+
+                  <Button
+                    disabled={selectedItems.length !== 1}
+                    onClick={() => handleEditDashboard(selectedItems[0])}
+                  >
+                    <FormattedMessage
+                      defaultMessage="Build"
+                      description="dashboards table header build button"
                     />
                   </Button>
 

--- a/apps/client/src/routes/dashboards/dashboards-index/styles.css
+++ b/apps/client/src/routes/dashboards/dashboards-index/styles.css
@@ -9,3 +9,7 @@
   background: var(--colors-button-hover) !important;
   border-color: var(--colors-button-hover) !important;
 }
+
+.dashboard-table-filter div div {
+  max-width: 100% !important;
+}

--- a/apps/client/src/store/view-mode/index.ts
+++ b/apps/client/src/store/view-mode/index.ts
@@ -1,0 +1,19 @@
+import { atom } from 'jotai';
+
+/**
+ * edit mode visibility store
+ */
+const isEditModeVisible = atom(false);
+
+/**
+ * Readonly edit mode visibility
+ */
+export const getDashboardEditMode = atom((get) => get(isEditModeVisible));
+
+/** Set isEditModeVisible in store */
+export const setDashboardEditMode = atom(
+  null,
+  (_get, set, isVisible: boolean) => {
+    set(isEditModeVisible, isVisible);
+  },
+);


### PR DESCRIPTION
![image](https://github.com/awslabs/iot-application/assets/81667589/ace7e25c-61b0-4741-baf8-2f1060970e06)

Issue: 
-> https://github.com/awslabs/iot-application/issues/1277
-> https://github.com/awslabs/iot-application/issues/1281

Description: When a user creates a dashboard, they should be brought directly to the edit mode & Add a new "build" button next to the "view" button, which opens the dashboard directly in "edit" mode

Changes done in the CR:
-> User redirected to edit mode on creating dashboard.
-> Added a new build button, which opens the dashboard directly in edit mode.
