### PR TITLE
fix: increase client test timeout

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
@@ -287,12 +287,12 @@ describe('<DashboardsIndexPage />', () => {
           );
         },
         {
-          timeout: 5000,
+          timeout: 10000,
         },
       );
 
       expect(getDashboardDescriptionTooLongError()).toBeVisible();
-    });
+    }, 10000);
 
     it('should remove the description validation error on cancel', async () => {
       const user = userEvent.setup();


### PR DESCRIPTION
# Description

Increased timeout for a test which seems to struggle on slower machines. This is a temporary workaround to reduce flakiness of the test.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
