### PR TITLE
fix: run workflows on rc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ run-name: Build action initiated by ${{ github.actor }}
 
 on:
   push:
-    branches: main
+    branches: [main, rc]
   pull_request:
-    branches: main
+    branches: [main, rc]
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,9 @@ run-name: CodeQL action initiated by ${{ github.actor }}
 
 on:
   push:
-    branches: main
+    branches: [main, rc]
   pull_request:
-    branches: main
+    branches: [main, rc]
   schedule:
     - cron: '26 3 * * 0'
 

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -4,8 +4,7 @@ run-name: Deployment action initiated by ${{ github.actor }}
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main, rc]
 
 # Ensures that only one deployment is in progress
 concurrency: ${{ github.workflow }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,8 +4,7 @@ run-name: Deployment action initiated by ${{ github.actor }}
 
 on:
   push:
-    branches:
-      - main
+    branches: [main, rc]
 
 # Ensures that only one deployment is in progress
 concurrency: ${{ github.workflow }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,9 @@ run-name: Lint action initiated by ${{ github.actor }}
 
 on:
   push:
-    branches: main
+    branches: [main, rc]
   pull_request:
-    branches: main
+    branches: [main, rc]
 
 jobs:
   lint:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,9 +4,9 @@ run-name: Playwright Test action initiated by ${{ github.actor }}
 
 on:
   push:
-    branches: main
+    branches: [main, rc]
   pull_request:
-    branches: main
+    branches: [main, rc]
 
 jobs:
   playwright:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ run-name: Unit Test action initiated by ${{ github.actor }}
 
 on:
   push:
-    branches: main
+    branches: [main, rc]
   pull_request:
-    branches: main
+    branches: [main, rc]
 
 jobs:
   test:


### PR DESCRIPTION
# Description

GitHub actions are not running on PRs created against the `rc` branch. This change resolves this issue.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
