### PR TITLE
fix: support line-scatter-chart name

### DIFF
--- a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
@@ -24,6 +24,22 @@ export function DashboardPage() {
   );
 
   const dashboardQuery = useDashboardQuery(params.dashboardId);
+
+  const dashboardDefinition = {
+    ...dashboardQuery.data?.definition,
+    widgets: dashboardQuery.data?.definition.widgets.map((widget) => {
+      // legacy naming support of line-scatter-chart
+      if (widget.type === 'line-scatter-chart') {
+        return {
+          ...widget,
+          type: 'xy-plot',
+        };
+      }
+
+      return widget;
+    }),
+  };
+
   const updateDashboardMutation = useUpdateDashboardMutation();
   const [viewport, saveViewport] = useViewport(params.dashboardId);
   if (dashboardQuery.isInitialLoading) {
@@ -39,7 +55,7 @@ export function DashboardPage() {
         awsRegion,
       }}
       dashboardConfiguration={{
-        ...dashboardQuery.data?.definition,
+        ...dashboardDefinition,
         // TODO: remove display settings once dynanic sizing is released
         displaySettings: {
           numRows: 600,

--- a/apps/client/src/services/generated/models/DashboardWidget.ts
+++ b/apps/client/src/services/generated/models/DashboardWidget.ts
@@ -4,6 +4,8 @@
 
 export type DashboardWidget = {
   type:
+    | 'xy-plot'
+    | 'line-scatter-chart'
     | 'line-chart'
     | 'scatter-chart'
     | 'bar-chart'


### PR DESCRIPTION
# Description

Support legacy naming of line chart.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
