### PR TITLE
feat: stretch input box for dashboard search to fill space

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -230,65 +230,68 @@ export function DashboardsIndexPage() {
             </Header>
           }
           filter={
-            <PropertyFilter
-              {...propertyFilterProps}
-              countText={intl.formatMessage(
-                {
-                  defaultMessage: `
+            // no props available for this in cloudscape to show full width
+            <div className="dashboard-table-filter">
+              <PropertyFilter
+                {...propertyFilterProps}
+                countText={intl.formatMessage(
+                  {
+                    defaultMessage: `
                 {dashboardCount, plural,
                   zero {# matches}
                   one {# match}
                   other {# matches}}
                 `,
-                  description: 'dashboards table filter count text',
-                },
-                { dashboardCount: filteredItemsCount },
-              )}
-              filteringPlaceholder={intl.formatMessage({
-                defaultMessage: 'Find dashboards',
-                description: 'dashboards table filter placeholder',
-              })}
-              // TODO: internationalize fields
-              filteringLoadingText="Loading suggestions"
-              filteringErrorText="Error fetching suggestions."
-              filteringRecoveryText="Retry"
-              filteringFinishedText="End of results"
-              filteringEmpty="No suggestions found"
-              i18nStrings={{
-                filteringAriaLabel: 'your choice',
-                dismissAriaLabel: 'Dismiss',
-                filteringPlaceholder:
-                  'Filter assets by text, property or value',
-                groupValuesText: 'Values',
-                groupPropertiesText: 'Properties',
-                operatorsText: 'Operators',
-                operationAndText: 'and',
-                operationOrText: 'or',
-                operatorLessText: 'Less than',
-                operatorLessOrEqualText: 'Less than or equal',
-                operatorGreaterText: 'Greater than',
-                operatorGreaterOrEqualText: 'Greater than or equal',
-                operatorContainsText: 'Contains',
-                operatorDoesNotContainText: 'Does not contain',
-                operatorEqualsText: 'Equals',
-                operatorDoesNotEqualText: 'Does not equal',
-                editTokenHeader: 'Edit filter',
-                propertyText: 'Property',
-                operatorText: 'Operator',
-                valueText: 'Value',
-                cancelActionText: 'Cancel',
-                applyActionText: 'Apply',
-                allPropertiesLabel: 'All properties',
-                tokenLimitShowMore: 'Show more',
-                tokenLimitShowFewer: 'Show fewer',
-                clearFiltersText: 'Clear filters',
-                removeTokenButtonAriaLabel: (token) =>
-                  `Remove token ${token.propertyKey ?? '{token}'} ${
-                    token.operator
-                  } ${token.value as string}`,
-                enteredTextLabel: (text) => `Use: "${text}"`,
-              }}
-            />
+                    description: 'dashboards table filter count text',
+                  },
+                  { dashboardCount: filteredItemsCount },
+                )}
+                filteringPlaceholder={intl.formatMessage({
+                  defaultMessage: 'Find dashboards',
+                  description: 'dashboards table filter placeholder',
+                })}
+                // TODO: internationalize fields
+                filteringLoadingText="Loading suggestions"
+                filteringErrorText="Error fetching suggestions."
+                filteringRecoveryText="Retry"
+                filteringFinishedText="End of results"
+                filteringEmpty="No suggestions found"
+                i18nStrings={{
+                  filteringAriaLabel: 'your choice',
+                  dismissAriaLabel: 'Dismiss',
+                  filteringPlaceholder:
+                    'Filter assets by text, property or value',
+                  groupValuesText: 'Values',
+                  groupPropertiesText: 'Properties',
+                  operatorsText: 'Operators',
+                  operationAndText: 'and',
+                  operationOrText: 'or',
+                  operatorLessText: 'Less than',
+                  operatorLessOrEqualText: 'Less than or equal',
+                  operatorGreaterText: 'Greater than',
+                  operatorGreaterOrEqualText: 'Greater than or equal',
+                  operatorContainsText: 'Contains',
+                  operatorDoesNotContainText: 'Does not contain',
+                  operatorEqualsText: 'Equals',
+                  operatorDoesNotEqualText: 'Does not equal',
+                  editTokenHeader: 'Edit filter',
+                  propertyText: 'Property',
+                  operatorText: 'Operator',
+                  valueText: 'Value',
+                  cancelActionText: 'Cancel',
+                  applyActionText: 'Apply',
+                  allPropertiesLabel: 'All properties',
+                  tokenLimitShowMore: 'Show more',
+                  tokenLimitShowFewer: 'Show fewer',
+                  clearFiltersText: 'Clear filters',
+                  removeTokenButtonAriaLabel: (token) =>
+                    `Remove token ${token.propertyKey ?? '{token}'} ${
+                      token.operator
+                    } ${token.value as string}`,
+                  enteredTextLabel: (text) => `Use: "${text}"`,
+                }}
+              />
+            </div>
           }
           preferences={
             <CollectionPreferences

--- a/apps/client/src/routes/dashboards/dashboards-index/styles.css
+++ b/apps/client/src/routes/dashboards/dashboards-index/styles.css
@@ -9,3 +9,7 @@
   background: var(--colors-button-hover) !important;
   border-color: var(--colors-button-hover) !important;
 }
+
+.dashboard-table-filter div div {
+  max-width: 100% !important;
+}


### PR DESCRIPTION
# Description

Stretch input box for dashboard search to fill space horizontally in the home page #1286 
![image](https://github.com/awslabs/iot-application/assets/142866907/cc45e44d-f97d-4b9f-bde4-9c457a24d18c)


## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
