### PR TITLE
feat: added a build button that takes user directly to edit mode #127…

### DIFF
--- a/apps/client/src/routes/dashboards/create/hooks/use-create-dashboard-mutation.tsx
+++ b/apps/client/src/routes/dashboards/create/hooks/use-create-dashboard-mutation.tsx
@@ -2,6 +2,7 @@ import Button from '@cloudscape-design/components/button';
 import { useMutation } from '@tanstack/react-query';
 import { useIntl, FormattedMessage } from 'react-intl';
 import invariant from 'tiny-invariant';
+import { useSetAtom } from 'jotai';
 
 import {
   cancelDashboardsQueries,
@@ -14,6 +15,7 @@ import { useEmitNotification } from '~/hooks/notifications/use-emit-notification
 import { useApplication } from '~/hooks/application/use-application';
 import { createDashboard } from '~/services';
 import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
+import { setDashboardEditMode } from '~/store/viewMode';
 
 import type { Dashboard } from '~/services';
 
@@ -21,6 +23,7 @@ export function useCreateDashboardMutation() {
   const emit = useEmitNotification();
   const intl = useIntl();
   const { navigate } = useApplication();
+  const emitEditMode = useSetAtom(setDashboardEditMode);
 
   return useMutation({
     mutationFn: (formData: Pick<Dashboard, 'name' | 'description'>) => {
@@ -35,6 +38,7 @@ export function useCreateDashboardMutation() {
       await prefetchDashboards();
 
       navigate(`/dashboards/${newDashboard.id}`);
+      emitEditMode(true);
 
       emit({
         type: 'success',

--- a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
@@ -5,6 +5,7 @@ import {
 import { Auth } from 'aws-amplify';
 import { useParams } from 'react-router-dom';
 import invariant from 'tiny-invariant';
+import { useAtomValue } from 'jotai';
 
 import { DashboardLoadingState } from './components/dashboard-loading-state';
 import { isJust } from '~/helpers/predicates/is-just';
@@ -14,9 +15,12 @@ import './styles.css';
 
 import type { DashboardDefinition } from '~/services';
 import { useViewport } from '~/hooks/dashboard/use-viewport';
+import { getDashboardEditMode } from '~/store/viewMode';
 
 export function DashboardPage() {
   const params = useParams<{ dashboardId: string }>();
+
+  const editMode = useAtomValue(getDashboardEditMode);
 
   invariant(
     isJust(params.dashboardId),
@@ -63,7 +67,7 @@ export function DashboardPage() {
         },
         viewport,
       }}
-      initialViewMode="preview"
+      initialViewMode={editMode ? 'edit' : 'preview'}
       onSave={(
         config: DashboardDefinition & Omit<DashboardConfiguration, 'widgets'>,
       ) => {

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.spec.tsx
@@ -165,6 +165,21 @@ describe('<DashboardsIndexPage />', () => {
     });
   });
 
+  it('should navigate to edit dashboard page when the Build button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DashboardsIndexPage />);
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select dashboard test name' }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Build' }));
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      `/dashboards/${getDashboardStubs()[0].id}`,
+    );
+  });
+
   describe('inline editing', () => {
     it('should render a validation error when the name is empty', async () => {
       const user = userEvent.setup();

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -17,6 +17,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import type { FormatDateOptions } from 'react-intl';
 import invariant from 'tiny-invariant';
+import { useSetAtom } from 'jotai';
 
 import { CREATE_DASHBOARD_HREF } from '~/constants';
 import { DeleteDashboardModal } from './components/delete-dashboard-modal';
@@ -30,6 +31,7 @@ import { useDeleteModalVisibility } from './hooks/use-delete-modal-visibility';
 import { usePartialUpdateDashboardMutation } from './hooks/use-partial-update-dashboard-mutation';
 import { useTablePreferences } from './hooks/use-table-preferences';
 import { $Dashboard, DashboardSummary } from '~/services';
+import { setDashboardEditMode } from '~/store/viewMode';
 
 import './styles.css';
 
@@ -43,6 +45,7 @@ const DateFormatOptions: FormatDateOptions = {
 };
 
 export function DashboardsIndexPage() {
+  const emitEditMode = useSetAtom(setDashboardEditMode);
   const intl = useIntl();
   const [isDeleteModalVisible, setIsDeleteModalVisible] =
     useDeleteModalVisibility();
@@ -110,6 +113,14 @@ export function DashboardsIndexPage() {
 
   const handleViewDashboard = (selected?: DashboardSummary) => {
     if (selected?.id) {
+      emitEditMode(false);
+      navigate(`/dashboards/${selected.id}`);
+    }
+  };
+
+  const handleEditDashboard = (selected?: DashboardSummary) => {
+    if (selected?.id) {
+      emitEditMode(true);
       navigate(`/dashboards/${selected.id}`);
     }
   };
@@ -119,6 +130,7 @@ export function DashboardsIndexPage() {
 
     invariant(isJust(event.detail.href), 'Expected href to be defined');
 
+    emitEditMode(false);
     navigate(event.detail.href);
   };
 
@@ -204,6 +216,16 @@ export function DashboardsIndexPage() {
                     <FormattedMessage
                       defaultMessage="View"
                       description="dashboards table header view button"
+                    />
+                  </Button>
+
+                  <Button
+                    disabled={selectedItems.length !== 1}
+                    onClick={() => handleEditDashboard(selectedItems[0])}
+                  >
+                    <FormattedMessage
+                      defaultMessage="Build"
+                      description="dashboards table header build button"
                     />
                   </Button>
 

--- a/apps/client/src/store/viewMode/index.ts
+++ b/apps/client/src/store/viewMode/index.ts
@@ -1,0 +1,19 @@
+import { atom } from 'jotai';
+
+/**
+ * edit mode visibility store
+ */
+const isEditModeVisible = atom(false);
+
+/**
+ * Readonly edit mode visibility
+ */
+export const getDashboardEditMode = atom((get) => get(isEditModeVisible));
+
+/** Set isEditModeVisible in store */
+export const setDashboardEditMode = atom(
+  null,
+  (_get, set, isVisible: boolean) => {
+    set(isEditModeVisible, isVisible);
+  },
+);

--- a/tests/dashboards/dashboard-management.spec.ts
+++ b/tests/dashboards/dashboard-management.spec.ts
@@ -40,7 +40,7 @@ test('as a user, I can create, update, and delete my dashboard', async ({
   );
 
   // check if viewport setting persists
-  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Preview' }).click();
   await page.getByRole('button', { name: 'Time machine' }).click();
   await page.getByRole('radio', { name: 'Last 5 minutes' }).click();
   await page.getByRole('button', { name: 'Apply' }).click();


### PR DESCRIPTION

![image](https://github.com/awslabs/iot-application/assets/81667589/1ed1892c-9cc5-4ff4-a910-89347573351c)


Issue:
-> https://github.com/awslabs/iot-application/issues/1277
-> https://github.com/awslabs/iot-application/issues/1281

Description: When a user creates a dashboard, they should be brought directly to the edit mode & Add a new "build" button next to the "view" button, which opens the dashboard directly in "edit" mode

Changes done in the CR:
-> User redirected to edit mode on creating dashboard.
-> Added a new build button, which opens the dashboard directly in edit mode.