### PR TITLE
fix: Docker build to copy built client artifact

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,7 @@
 **/lerna-debug.log*
 
 **/node_modules
-**/build
+**/!.client/build
 **/dist
 **/dist-ssr
 **/*.local

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Dependencies 🔩
         run: yarn install --frozen-lockfile
 
+      - name: Build Client 👷
+        run: yarn workspace client build
+
       - name: Configure AWS credentials 🔑
         uses: aws-actions/configure-aws-credentials@v3
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Dependencies 🔩
         run: yarn install --frozen-lockfile
 
+      - name: Build Client 👷
+        run: yarn workspace client build
+
       - name: Configure AWS credentials 🔑
         uses: aws-actions/configure-aws-credentials@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,14 @@ RUN yarn add global nest turbo typescript
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
 COPY ./turbo.json ./turbo.json
-COPY ./apps/client ./apps/client/
 COPY ./apps/core ./apps/core/
 COPY ./packages/tsconfig ./packages/tsconfig/
 
 # Install all dependencies
 RUN yarn install
 
-# Build both client and core
-RUN yarn build
+# Build core
+RUN yarn workspace core build
 
 FROM --platform=linux/amd64 node:alpine as core-modules-installer
 
@@ -34,7 +33,7 @@ COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
 COPY ./apps/core/package.json ./apps/core/package.json
 
-# # Install dependencies for core only
+# Install dependencies for core only
 RUN yarn install --production
 
 FROM --platform=linux/amd64  node:alpine as packager
@@ -45,8 +44,11 @@ WORKDIR /usr/src/app
 COPY --from=core-modules-installer /usr/src/core-modules/node_modules ./node_modules/
 COPY --from=core-modules-installer /usr/src/core-modules/apps/core/node_modules ./apps/core/node_modules/
 
+# Copy the yarn.lock
+COPY --from=builder /usr/src/app-build/yarn.lock ./yarn.lock
+
 # Copy the client build
-COPY --from=builder /usr/src/app-build/apps/client/build ./apps/client/build/
+COPY ./apps/client/build ./apps/client/build/
 
 # Copy the core build
 COPY --from=builder /usr/src/app-build/apps/core/dist ./apps/core/dist/

--- a/deploymentguide/README.md
+++ b/deploymentguide/README.md
@@ -27,6 +27,10 @@ Note: All commands should be run in the workspace root directory. We are using [
    ```sh
    yarn install
    ```
+1. Build the Client code:
+   ```sh
+   yarn workspace client build
+   ```
 1. Deploy the Core service and resource dependencies:
    ```sh
    yarn workspace cdk cdk deploy --all


### PR DESCRIPTION
# Description

## What

With this PR, client build happens outside of the docker build process so it has the dependencies installed with the lock file.

## Why

Currently, there’s a problem in deployment where client is failing to build on docker ([failure](https://github.com/awslabs/iot-application/actions/runs/6590030875/job/17905789877#step:7:501), [code](https://github.com/awslabs/iot-application/blob/main/Dockerfile#L22))
It is caused by dependency updates. Under docker build, the dependencies not installed with `--frozen-lockfile` so dependency updates could affect the docker build process. When running with `frozen-lockfile`, there's the following error due to incompatible between lock file and the docker image:`Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.` We also have no way to reconstruct the previous stable lock file.

# How Has This Been Tested?

Successfully [build run](https://github.com/awslabs/iot-application/actions/runs/6593383126/job/17915755093?pr=1530)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
