### PR TITLE
fix: increase heap size to prevent CI build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,6 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build Application 👷
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: yarn build


### PR DESCRIPTION
# Description

This change should resolve JS heap allocation exceptions being thrown during CI build by increasing the size of the heap.

Example failures:
https://github.com/awslabs/iot-application/actions/runs/6593297488/job/17915530208?pr=1541#step:6:38
https://github.com/awslabs/iot-application/actions/runs/6593293846/job/17915521101?pr=1540#step:6:36
https://github.com/awslabs/iot-application/actions/runs/6580649725/job/17879087238?pr=1524#step:6:38

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
