### PR TITLE
fix: docker image to build with node version 18 image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,7 @@
 **/lerna-debug.log*
 
 **/node_modules
-**/!.client/build
+**/build
 **/dist
 **/dist-ssr
 **/*.local

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Install Dependencies 🔩
         run: yarn install --frozen-lockfile
 
-      - name: Build Client 👷
-        run: yarn workspace client build
-
       - name: Configure AWS credentials 🔑
         uses: aws-actions/configure-aws-credentials@v3
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Install Dependencies 🔩
         run: yarn install --frozen-lockfile
 
-      - name: Build Client 👷
-        run: yarn workspace client build
-
       - name: Configure AWS credentials 🔑
         uses: aws-actions/configure-aws-credentials@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=linux/amd64 node:alpine as builder
+FROM --platform=linux/amd64 node:18-alpine as builder
 
 WORKDIR /usr/src/app-build
 
@@ -24,7 +24,7 @@ RUN yarn install
 # Build both client and core
 RUN yarn build
 
-FROM --platform=linux/amd64 node:alpine as core-modules-installer
+FROM --platform=linux/amd64 node:18-alpine as core-modules-installer
 
 WORKDIR /usr/src/core-modules
 
@@ -34,16 +34,19 @@ COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
 COPY ./apps/core/package.json ./apps/core/package.json
 
-# # Install dependencies for core only
+# Install dependencies for core only
 RUN yarn install --production
 
-FROM --platform=linux/amd64  node:alpine as packager
+FROM --platform=linux/amd64  node:18-alpine as packager
 
 WORKDIR /usr/src/app
 
 # Copy the node_modules
 COPY --from=core-modules-installer /usr/src/core-modules/node_modules ./node_modules/
 COPY --from=core-modules-installer /usr/src/core-modules/apps/core/node_modules ./apps/core/node_modules/
+
+# Copy the yarn.lock
+COPY --from=builder /usr/src/app-build/yarn.lock ./yarn.lock
 
 # Copy the client build
 COPY --from=builder /usr/src/app-build/apps/client/build ./apps/client/build/

--- a/deploymentguide/README.md
+++ b/deploymentguide/README.md
@@ -27,10 +27,6 @@ Note: All commands should be run in the workspace root directory. We are using [
    ```sh
    yarn install
    ```
-1. Build the Client code:
-   ```sh
-   yarn workspace client build
-   ```
 1. Deploy the Core service and resource dependencies:
    ```sh
    yarn workspace cdk cdk deploy --all


### PR DESCRIPTION
# Description

Node Docker image without specific version can cause build failure or code bug due to incompatibility between Node version and dependency packages.

# How Has This Been Tested?

Deployment workflow succeeded 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
