### PR TITLE
feat: Add migration GET API, tanstack query and UX logic

### DIFF
--- a/apps/client/src/data/migration.ts
+++ b/apps/client/src/data/migration.ts
@@ -1,0 +1,17 @@
+import { dashboardMigration, dashboardMigrationStatus } from '~/services';
+
+export const MIGRATION_QUERY_KEY = ['migration'];
+
+export const MIGRATION_START_QUERY_KEY = [...MIGRATION_QUERY_KEY, 'start'];
+
+export const MIGRATION_STATUS_QUERY_KEY = [...MIGRATION_QUERY_KEY, 'status'];
+
+export const MIGRATION_QUERY = {
+  queryKey: MIGRATION_START_QUERY_KEY,
+  queryFn: dashboardMigration,
+};
+
+export const MIGRATION_STATUS_QUERY = {
+  queryKey: MIGRATION_STATUS_QUERY_KEY,
+  queryFn: dashboardMigrationStatus,
+};

--- a/apps/client/src/routes/dashboards/dashboards-index/components/migration.spec.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/migration.spec.tsx
@@ -1,11 +1,108 @@
+import { vi } from 'vitest';
 import { render, screen } from '~/helpers/tests/testing-library';
-
+import { useMigrationStatusQuery } from '../hooks/use-migration-status-query';
+import { UseQueryResult } from '@tanstack/react-query';
+import {
+  MigrationStatus,
+  Status,
+} from '~/services/generated/models/MigrationStatus';
+import userEvent from '@testing-library/user-event';
 import Migration from './migration';
 
+const mockRefetch = vi.fn();
+
+vi.mock('../hooks/use-migration-query', () => ({
+  useMigrationQuery: () => ({
+    refetch: mockRefetch,
+  }),
+}));
+
+vi.mock('../hooks/use-migration-status-query');
+
+const getMigrationButton = () =>
+  screen.getByRole('button', { name: 'Migrate' });
+
 describe('Migration', () => {
-  test('Migration form loads', () => {
+  beforeEach(() => {
+    vi.mocked(useMigrationStatusQuery).mockReturnValue({
+      data: {
+        status: Status.NOT_STARTED,
+      },
+    } as UseQueryResult<MigrationStatus>);
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('initial form loads', () => {
     render(<Migration />);
 
     expect(screen.getByText('Dashboard migration')).toBeVisible();
+  });
+
+  test('clicking migrate button starts migration', async () => {
+    render(<Migration />);
+
+    expect(screen.getByText('Dashboard migration')).toBeVisible();
+
+    await userEvent.click(getMigrationButton());
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('display in-progress message when migration API is in progress', () => {
+    vi.mocked(useMigrationStatusQuery).mockReturnValue({
+      data: {
+        status: Status.IN_PROGRESS,
+      },
+    } as UseQueryResult<MigrationStatus>);
+
+    render(<Migration />);
+
+    expect(screen.getByText('Dashboard migration')).toBeVisible();
+    expect(screen.getByText('Migration in-progress')).toBeVisible();
+  });
+
+  test('display complete message when migration API is complete', () => {
+    vi.mocked(useMigrationStatusQuery).mockReturnValue({
+      data: {
+        status: Status.COMPLETE,
+      },
+    } as UseQueryResult<MigrationStatus>);
+    render(<Migration />);
+
+    expect(screen.getByText('Dashboard migration')).toBeVisible();
+    expect(screen.getByText('Migration complete')).toBeVisible();
+  });
+
+  test('displays error for migration failing', () => {
+    vi.mocked(useMigrationStatusQuery).mockReturnValue({
+      data: {
+        status: Status.ERROR,
+        message: 'There was a migration error',
+      },
+    } as UseQueryResult<MigrationStatus>);
+    render(<Migration />);
+
+    expect(screen.getByText('Dashboard migration')).toBeVisible();
+    expect(
+      screen.getByText(
+        'There was an error during migration: There was a migration error',
+      ),
+    ).toBeVisible();
+  });
+
+  test('displays error for general api errors', () => {
+    vi.mocked(useMigrationStatusQuery).mockReturnValue({
+      data: {
+        status: Status.IN_PROGRESS,
+      },
+      isError: true,
+    } as UseQueryResult<MigrationStatus>);
+    render(<Migration />);
+
+    expect(
+      screen.getByText('There was an error during migration'),
+    ).toBeVisible();
   });
 });

--- a/apps/client/src/routes/dashboards/dashboards-index/components/migration.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/migration.tsx
@@ -5,15 +5,46 @@ import ColumnLayout from '@cloudscape-design/components/column-layout';
 import ExpandableSection from '@cloudscape-design/components/expandable-section';
 import { FormattedMessage } from 'react-intl';
 import { colorBackgroundHomeHeader } from '@cloudscape-design/design-tokens';
-import { dashboardMigration } from '~/services';
-
-const click = () => {
-  async () => {
-    await dashboardMigration();
-  };
-};
+import { useMigrationStatusQuery } from '../hooks/use-migration-status-query';
+import { useMigrationQuery } from '../hooks/use-migration-query';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import { Status } from '~/services/generated/models/MigrationStatus';
 
 const Migration = () => {
+  // TODO: handle more API errors once API is implemented
+  const { data, isError } = useMigrationStatusQuery();
+  const { refetch, isRefetching } = useMigrationQuery();
+
+  let statusElement;
+
+  if (isRefetching || data?.status === Status.IN_PROGRESS) {
+    statusElement = (
+      <StatusIndicator type="loading">Migration in-progress</StatusIndicator>
+    );
+  }
+
+  if (data?.status === Status.COMPLETE) {
+    statusElement = (
+      <StatusIndicator type="success">Migration complete</StatusIndicator>
+    );
+  }
+
+  if (isError) {
+    statusElement = (
+      <StatusIndicator type="error">
+        There was an error during migration
+      </StatusIndicator>
+    );
+  }
+
+  if (data?.status === Status.ERROR) {
+    statusElement = (
+      <StatusIndicator type="error">
+        There was an error during migration: {data.message}
+      </StatusIndicator>
+    );
+  }
+
   return (
     <ExpandableSection
       defaultExpanded={false}
@@ -25,16 +56,19 @@ const Migration = () => {
         />
       }
     >
-      <ColumnLayout columns={2}>
+      <ColumnLayout columns={3}>
         <Box>
           You can migrate your dashboards from SiteWise Monitor to IoT
           Application.
         </Box>
+        <Box textAlign="center">{statusElement}</Box>
         <Box float="right">
           <Button
             variant="primary"
             className="btn-custom-primary"
-            onClick={click}
+            onClick={() => {
+              void refetch();
+            }}
           >
             <span style={{ color: colorBackgroundHomeHeader }}>
               <FormattedMessage

--- a/apps/client/src/routes/dashboards/dashboards-index/hooks/use-migration-query.ts
+++ b/apps/client/src/routes/dashboards/dashboards-index/hooks/use-migration-query.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { MIGRATION_QUERY } from '~/data/migration';
+
+export function useMigrationQuery() {
+  return useQuery({
+    ...MIGRATION_QUERY,
+    refetchOnWindowFocus: false,
+    enabled: false, // only call this API on button click once using refetch()
+  });
+}

--- a/apps/client/src/routes/dashboards/dashboards-index/hooks/use-migration-status-query.ts
+++ b/apps/client/src/routes/dashboards/dashboards-index/hooks/use-migration-status-query.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { MIGRATION_STATUS_QUERY } from '~/data/migration';
+
+export function useMigrationStatusQuery() {
+  return useQuery({
+    ...MIGRATION_STATUS_QUERY,
+    refetchInterval: 2000,
+    staleTime: 0,
+    cacheTime: 0,
+  });
+}

--- a/apps/client/src/services/generated/models/MigrationStatus.ts
+++ b/apps/client/src/services/generated/models/MigrationStatus.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum Status {
+  NOT_STARTED = 'not-started',
+  IN_PROGRESS = 'in-progress',
+  COMPLETE = 'complete',
+  ERROR = 'error'
+}
+  
+export type MigrationStatus = {
+  status: Status;
+  message?: string;
+}

--- a/apps/client/src/services/generated/services/MigrationService.ts
+++ b/apps/client/src/services/generated/services/MigrationService.ts
@@ -1,19 +1,30 @@
-/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { MigrationStatus } from '../models/MigrationStatus';
 
 export class MigrationService {
   /**
-   * @returns any
+   * @returns void
    * @throws ApiError
    */
-  public static migrationControllerMigration(): CancelablePromise<any> {
+  public static migrationControllerMigration() {
     return __request(OpenAPI, {
       method: 'POST',
+      url: '/migration',
+    });
+  }
+
+  /**
+   * @returns MigrationStatus
+   * @throws ApiError
+   */
+  public static migrationControllerGetMigrationStatus(): CancelablePromise<MigrationStatus> {
+    return __request(OpenAPI, {
+      method: 'GET',
       url: '/migration',
     });
   }

--- a/apps/client/src/services/index.ts
+++ b/apps/client/src/services/index.ts
@@ -43,6 +43,10 @@ export const bulkDeleteDashboards: BulkDeleteDashboards = (ids) =>
 // Migration API
 export type DashboardMigration =
   typeof MigrationService.migrationControllerMigration;
+export type DashboardMigrationStatus =
+  typeof MigrationService.migrationControllerGetMigrationStatus;
 
 export const dashboardMigration: DashboardMigration = () =>
   MigrationService.migrationControllerMigration();
+export const dashboardMigrationStatus: DashboardMigrationStatus = () =>
+  MigrationService.migrationControllerGetMigrationStatus();

--- a/apps/core/src/migration/entities/migration-status.entity.ts
+++ b/apps/core/src/migration/entities/migration-status.entity.ts
@@ -1,0 +1,22 @@
+import { IsString } from 'class-validator';
+
+export enum Status {
+  NOT_STARTED = 'not-started',
+  IN_PROGRESS = 'in-progress',
+  COMPLETE = 'complete',
+  ERROR = 'error',
+}
+
+export class MigrationStatus {
+  /**
+   * @example "in-progress"
+   */
+  @IsString()
+  public readonly status: Status;
+
+  /**
+   * @example "error calling API ListPortals: you do not have permission."
+   */
+  @IsString()
+  public readonly message?: string;
+}

--- a/apps/core/src/migration/migration.controller.ts
+++ b/apps/core/src/migration/migration.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Post } from '@nestjs/common';
+import { Controller, HttpCode, Get, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { MigrationService } from './migration.service';
+import { MigrationStatus } from './entities/migration-status.entity';
 
 @ApiTags('migration')
 @Controller('api/migration')
@@ -8,8 +9,13 @@ export class MigrationController {
   constructor(private readonly migrationService: MigrationService) {}
 
   @Post()
+  @HttpCode(202)
   public migration() {
-    // Purposely don't use await so this request can process after the response
-    return this.migrationService.migrate();
+    this.migrationService.migrate();
+  }
+
+  @Get()
+  public getMigrationStatus(): MigrationStatus {
+    return this.migrationService.getMigrationStatus();
   }
 }

--- a/apps/core/src/migration/migration.e2e.spec.ts
+++ b/apps/core/src/migration/migration.e2e.spec.ts
@@ -7,6 +7,7 @@ import { Test } from '@nestjs/testing';
 import { AppModule } from '../app.module';
 import { configureTestProcessEnv } from '../testing/aws-configuration';
 import { getAccessToken } from '../testing/jwt-generator';
+import { MigrationStatus, Status } from './entities/migration-status.entity';
 
 describe('DashboardsModule', () => {
   let bearerToken = '';
@@ -41,7 +42,7 @@ describe('DashboardsModule', () => {
   });
 
   describe('POST /api/migration HTTP/1.1', () => {
-    test('calls migration', async () => {
+    test('starts migration after receiving request', async () => {
       const response = await app.inject({
         headers: {
           Authorization: `Bearer ${bearerToken}`,
@@ -50,7 +51,40 @@ describe('DashboardsModule', () => {
         url: '/api/migration',
       });
 
-      expect(response.statusCode).toBe(201);
+      expect(response.statusCode).toBe(202);
+    });
+
+    test('returns 401 when request is unauthenticated', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/migration',
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe('GET /api/migration HTTP/1.1', () => {
+    test('gets migration status', async () => {
+      const response = await app.inject({
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        method: 'GET',
+        url: '/api/migration',
+      });
+      const status = JSON.parse(response.payload) as unknown as MigrationStatus;
+      expect(status).toEqual({ status: Status.IN_PROGRESS });
+      expect(response.statusCode).toBe(200);
+    });
+
+    test('returns 401 when request is unauthenticated', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/migration',
+      });
+
+      expect(response.statusCode).toBe(401);
     });
   });
 });

--- a/apps/core/src/migration/migration.module.ts
+++ b/apps/core/src/migration/migration.module.ts
@@ -1,12 +1,11 @@
 import { Module, ModuleMetadata } from '@nestjs/common';
 
 import { MigrationController } from './migration.controller';
-import { DashboardsRepository } from '../dashboards/dashboards.repository';
 import { MigrationService } from './migration.service';
 
 export const migrationModuleMetadata: ModuleMetadata = {
   controllers: [MigrationController],
-  providers: [DashboardsRepository, MigrationService],
+  providers: [MigrationService],
 };
 
 /** Core Dashboards Module */

--- a/apps/core/src/migration/migration.service.ts
+++ b/apps/core/src/migration/migration.service.ts
@@ -1,12 +1,63 @@
 import { Injectable } from '@nestjs/common';
+import { MigrationStatus, Status } from './entities/migration-status.entity';
+
+const delay = (ms: number) => {
+  return new Promise((res) => setTimeout(res, ms));
+};
 
 @Injectable()
 export class MigrationService {
+  private migrationStatus: MigrationStatus = {
+    status: Status.NOT_STARTED,
+  };
+
+  private getSiteWiseMonitorInformation() {
+    // ListPortals
+    // ListProjects
+    // ListDashboards
+    // DescribeDashboard
+  }
+
+  private convertDashboardDefinitions() {
+    // Determine mapping between definitions
+  }
+
+  private createApplicationDashboards() {
+    // For each dashboards call Application CreateDashboard
+  }
+
+  private async process() {
+    // Simulate a time delay and status updated until we implement the actual migration
+    // TODO: Remove this code
+    await delay(5000);
+    this.migrationStatus = {
+      status: Status.ERROR,
+      message: 'There was an error',
+    };
+    await delay(5000);
+    this.migrationStatus = { status: Status.IN_PROGRESS };
+    await delay(5000);
+    this.migrationStatus = { status: Status.COMPLETE };
+
+    // TODO: add functionality
+    this.getSiteWiseMonitorInformation();
+    this.convertDashboardDefinitions();
+    this.createApplicationDashboards();
+  }
+
+  // Purposely don't use async/await so we can return the inital status first
   public migrate() {
-    // TODO:
-    // Get SWM dashboards
-    // Convert dashboard definitions
-    // Create IoT Application dashboards
-    return;
+    if (
+      this.migrationStatus.status === Status.NOT_STARTED ||
+      this.migrationStatus.status === Status.COMPLETE
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.process();
+      this.migrationStatus = { status: Status.IN_PROGRESS };
+    }
+  }
+
+  public getMigrationStatus(): MigrationStatus {
+    return this.migrationStatus;
   }
 }


### PR DESCRIPTION
# Description

* Added /GET endpoint that returns the status of the migration and UX elements that update based on this status
   * One thing to note is I'm using the core migration class' private variable to store the status. From my testing this seems to work without needing to use local storage or a db. NestJS creates singleton service instances that will live long enough for the migration to take place. The status remains consistent on user refreshes and upon calling the /POST endpoint multiple times in a row. Only one migration occurs and the status is communicated as expected. If we move to a distributed compute model we can store status in local storage or a db.
* Changed the migration /POST and /GET calls on the client to use tanstack query
* Right now mocking out the actual migration steps by using waits and changing the status for testing, next step is implementing the migration logic

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual validation
- [X] Unit tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
