### PR TITLE
fix: configured Node memory allocation to 4GB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM --platform=linux/amd64 node:18-alpine as builder
 
 WORKDIR /usr/src/app-build
 
+# Configure Node memory allocation
+ENV NODE_OPTIONS=--max_old_space_size=4096
+
 # Install missing dep for turbo
 RUN apk add --no-cache libc6-compat
 


### PR DESCRIPTION
# Description

fixed docker client build by allocating Node memory to 4GB

# How Has This Been Tested?

Passing workflow https://github.com/awslabs/iot-application/actions/runs/6671111845/job/18132488483?pr=1605

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
