### PR TITLE
fix: updated the wcag compliance for dashboard table inline edit buttons

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -196,6 +196,21 @@ export function DashboardsIndexPage() {
                 defaultMessage: 'Select dashboard checkbox',
                 description: 'dashboards table selection checkbox label',
               }),
+            cancelEditLabel: () =>
+              intl.formatMessage({
+                defaultMessage: 'Cancel inline table edit',
+                description: 'dashboards table inline cancel edit label',
+              }),
+            submitEditLabel: () =>
+              intl.formatMessage({
+                defaultMessage: 'Submit inline table edit',
+                description: 'dashboards table inline edit submit label',
+              }),
+            activateEditLabel: () =>
+              intl.formatMessage({
+                defaultMessage: 'Activate inline table edit',
+                description: 'dashboards table inline edit activate label',
+              }),
           }}
           submitEdit={async (item, column) => {
             invariant(column.id, 'Expected column to be defined');


### PR DESCRIPTION
# Description
Description:
updated the WCAG compliance for dashboard table inline edit buttons. (edit, cancel edit and submit buttons)

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
