### PR TITLE
feat: migration - add SWM dashboard fetching, update UX

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -166,7 +166,9 @@ export function DashboardsIndexPage() {
       </Box>
       {featureEnabled(Features.MIGRATION) && (
         <Box padding={{ top: 'l' }}>
-          <Migration />
+          <Migration
+            onMigrationComplete={() => void dashboardsQuery.refetch()}
+          />
         </Box>
       )}
       <Box padding={{ top: 'l' }}>

--- a/apps/client/src/store/notifications/index.ts
+++ b/apps/client/src/store/notifications/index.ts
@@ -42,20 +42,32 @@ export const emitNotificationAtom = atom(
   ) => {
     const notificationId = nanoid();
 
-    set(notificationsBaseAtom, () => [
-      {
-        ...notification,
-        id: notificationId,
-        dismissible: true,
-        onDismiss: () => {
-          set(dismissNotificationAtom, notificationId);
+    // For Migration only display one status notification at a time
+    const existingNotifications = get(notificationsAtom);
+    const foundDuplicate = existingNotifications.find(
+      (notif) => notif.content === notification.content,
+    );
+    const preventNotification =
+      foundDuplicate &&
+      typeof notification.content === 'string' &&
+      notification.content.toLowerCase().includes('migration');
+
+    if (!preventNotification) {
+      set(notificationsBaseAtom, () => [
+        {
+          ...notification,
+          id: notificationId,
+          dismissible: true,
+          onDismiss: () => {
+            set(dismissNotificationAtom, notificationId);
+          },
+          dismissLabel: intl.formatMessage({
+            defaultMessage: 'Dismiss notification',
+            description: 'dismiss notification aria label',
+          }),
         },
-        dismissLabel: intl.formatMessage({
-          defaultMessage: 'Dismiss notification',
-          description: 'dismiss notification aria label',
-        }),
-      },
-      ...get(notificationsAtom),
-    ]);
+        ...get(notificationsAtom),
+      ]);
+    }
   },
 );

--- a/apps/client/src/structures/notifications/loading-notification.spec.ts
+++ b/apps/client/src/structures/notifications/loading-notification.spec.ts
@@ -1,0 +1,13 @@
+import { Notification } from './notification';
+import { LoadingNotification } from './loading-notification';
+
+describe('LoadingNotification', () => {
+  it('should create a loading notification', () => {
+    const notification = new LoadingNotification('test');
+
+    expect(notification).toBeInstanceOf(Notification);
+    expect(notification.type).toBe('success');
+    expect(notification.loading).toBe(true);
+    expect(notification.content).toBe('test');
+  });
+});

--- a/apps/client/src/structures/notifications/loading-notification.ts
+++ b/apps/client/src/structures/notifications/loading-notification.ts
@@ -1,0 +1,7 @@
+import { Notification } from './notification';
+
+export class LoadingNotification extends Notification {
+  constructor(content: string) {
+    super('success', content, true);
+  }
+}

--- a/apps/client/src/structures/notifications/notification.ts
+++ b/apps/client/src/structures/notifications/notification.ts
@@ -4,5 +4,6 @@ export class Notification {
   constructor(
     public readonly type: NotificationViewModel['type'],
     public readonly content: NotificationViewModel['content'],
+    public readonly loading?: NotificationViewModel['loading'],
   ) {}
 }

--- a/apps/core/src/dashboards/dashboards.module.ts
+++ b/apps/core/src/dashboards/dashboards.module.ts
@@ -7,6 +7,7 @@ import { DashboardsService } from './dashboards.service';
 export const dashboardsModuleMetadata: ModuleMetadata = {
   controllers: [DashboardsController],
   providers: [DashboardsRepository, DashboardsService],
+  exports: [DashboardsService],
 };
 
 /** Core Dashboards Module */

--- a/apps/core/src/migration/migration.module.ts
+++ b/apps/core/src/migration/migration.module.ts
@@ -2,8 +2,10 @@ import { Module, ModuleMetadata } from '@nestjs/common';
 
 import { MigrationController } from './migration.controller';
 import { MigrationService } from './migration.service';
+import { DashboardsModule } from '../dashboards/dashboards.module';
 
 export const migrationModuleMetadata: ModuleMetadata = {
+  imports: [DashboardsModule],
   controllers: [MigrationController],
   providers: [MigrationService],
 };

--- a/apps/core/src/migration/migration.service.ts
+++ b/apps/core/src/migration/migration.service.ts
@@ -1,48 +1,202 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { MigrationStatus, Status } from './entities/migration-status.entity';
-
-const delay = (ms: number) => {
-  return new Promise((res) => setTimeout(res, ms));
-};
+import { DashboardsService } from '../dashboards/dashboards.service';
+import {
+  IoTSiteWiseClient,
+  ListPortalsCommand,
+  ListProjectsCommand,
+  ListDashboardsCommand,
+  DescribeDashboardCommand,
+  DescribeDashboardCommandOutput,
+  PortalSummary,
+  ProjectSummary,
+  DashboardSummary,
+} from '@aws-sdk/client-iotsitewise';
+import { CreateDashboardDto } from 'src/dashboards/dto/create-dashboard.dto';
+import { convertSiteWiseMonitorToApplicationDefinition } from './util/convertSiteWiseMonitorToApplicationDefinition';
 
 @Injectable()
 export class MigrationService {
+  @Inject(DashboardsService)
+  private readonly dashboardsService: DashboardsService;
+
   private migrationStatus: MigrationStatus = {
     status: Status.NOT_STARTED,
   };
 
-  private getSiteWiseMonitorInformation() {
-    // ListPortals
-    // ListProjects
-    // ListDashboards
-    // DescribeDashboard
+  private sitewise = new IoTSiteWiseClient({
+    credentials: {
+      accessKeyId: this.getAccessKey(),
+      secretAccessKey: this.getSecretKey(),
+    },
+    region: this.getRegion(),
+  });
+
+  private getRegion() {
+    return process.env.AWS_REGION;
   }
 
-  private convertDashboardDefinitions() {
-    // Determine mapping between definitions
+  private getAccessKey() {
+    if (process.env.AWS_ACCESS_KEY_ID) {
+      return process.env.AWS_ACCESS_KEY_ID;
+    }
+    return '';
   }
 
-  private createApplicationDashboards() {
-    // For each dashboards call Application CreateDashboard
+  private getSecretKey() {
+    if (process.env.AWS_SECRET_ACCESS_KEY) {
+      return process.env.AWS_SECRET_ACCESS_KEY;
+    }
+    return '';
   }
 
+  private async getPortals(): Promise<PortalSummary[]> {
+    const portals: PortalSummary[] = [];
+
+    let response = await this.sitewise.send(new ListPortalsCommand({}));
+
+    if (response.portalSummaries) {
+      portals.push(...response.portalSummaries);
+
+      while (response.nextToken) {
+        response = await this.sitewise.send(
+          new ListPortalsCommand({ nextToken: response.nextToken }),
+        );
+
+        if (response.portalSummaries) {
+          portals.push(...response.portalSummaries);
+        }
+      }
+    }
+
+    return portals;
+  }
+
+  private async getProjects(
+    portals: PortalSummary[],
+  ): Promise<ProjectSummary[]> {
+    const projects: ProjectSummary[] = [];
+
+    for (const { id } of portals) {
+      let response = await this.sitewise.send(
+        new ListProjectsCommand({ portalId: id }),
+      );
+      if (response.projectSummaries) {
+        projects.push(...response.projectSummaries);
+
+        while (response.nextToken) {
+          response = await this.sitewise.send(
+            new ListProjectsCommand({
+              portalId: id,
+              nextToken: response.nextToken,
+            }),
+          );
+
+          if (response.projectSummaries) {
+            projects.push(...response.projectSummaries);
+          }
+        }
+      }
+    }
+
+    return projects;
+  }
+
+  private async getDashboards(
+    projects: ProjectSummary[],
+  ): Promise<DashboardSummary[]> {
+    const dashboards: DashboardSummary[] = [];
+
+    for (const { id } of projects) {
+      let response = await this.sitewise.send(
+        new ListDashboardsCommand({ projectId: id }),
+      );
+
+      if (response.dashboardSummaries) {
+        dashboards.push(...response.dashboardSummaries);
+
+        while (response.nextToken) {
+          response = await this.sitewise.send(
+            new ListDashboardsCommand({
+              projectId: id,
+              nextToken: response.nextToken,
+            }),
+          );
+
+          if (response.dashboardSummaries) {
+            dashboards.push(...response.dashboardSummaries);
+          }
+        }
+      }
+    }
+
+    return dashboards;
+  }
+
+  private async getDescribedDashboards(
+    dashboards: DashboardSummary[],
+  ): Promise<DescribeDashboardCommandOutput[]> {
+    const describedDashboards: DescribeDashboardCommandOutput[] = [];
+
+    for (const { id } of dashboards) {
+      const dashboard = await this.sitewise.send(
+        new DescribeDashboardCommand({ dashboardId: id }),
+      );
+      describedDashboards.push(dashboard);
+    }
+
+    return describedDashboards;
+  }
+
+  private async getSiteWiseMonitorInformation(): Promise<
+    DescribeDashboardCommandOutput[]
+  > {
+    const portals = await this.getPortals();
+    const projects = await this.getProjects(portals);
+    const dashboards = await this.getDashboards(projects);
+    return await this.getDescribedDashboards(dashboards);
+  }
+
+  private convertSWMToApplicationDashboards(
+    siteWiseMonitorDashboards: DescribeDashboardCommandOutput[],
+  ): CreateDashboardDto[] {
+    return siteWiseMonitorDashboards.map((dashboard) => ({
+      name: dashboard.dashboardName
+        ? dashboard.dashboardName
+        : 'SiteWise Monitor Migrated Dashboard',
+      description: dashboard.dashboardDescription
+        ? dashboard.dashboardDescription
+        : '',
+      definition: convertSiteWiseMonitorToApplicationDefinition(
+        dashboard.dashboardDefinition,
+      ),
+    }));
+  }
+
+  private async createApplicationDashboards(
+    siteWiseMonitorDashboards: CreateDashboardDto[],
+  ) {
+    for (const dashboard of siteWiseMonitorDashboards) {
+      await this.dashboardsService.create(dashboard);
+    }
+  }
+
+  // TODO: finish functionality
   private async process() {
-    // Simulate a time delay and status updated until we implement the actual migration
-    // TODO: Remove this code
-    await delay(5000);
-    this.migrationStatus = {
-      status: Status.ERROR,
-      message: 'There was an error',
-    };
-    await delay(5000);
     this.migrationStatus = { status: Status.IN_PROGRESS };
-    await delay(5000);
-    this.migrationStatus = { status: Status.COMPLETE };
 
-    // TODO: add functionality
-    this.getSiteWiseMonitorInformation();
-    this.convertDashboardDefinitions();
-    this.createApplicationDashboards();
+    const dashboards: DescribeDashboardCommandOutput[] =
+      await this.getSiteWiseMonitorInformation();
+
+    if (dashboards.length) {
+      const convertedDashboards =
+        this.convertSWMToApplicationDashboards(dashboards);
+      await this.createApplicationDashboards(convertedDashboards);
+      this.migrationStatus = { status: Status.COMPLETE };
+    } else {
+      // No SWM dashboards to convert
+      this.migrationStatus = { status: Status.COMPLETE };
+    }
   }
 
   // Purposely don't use async/await so we can return the inital status first
@@ -51,13 +205,24 @@ export class MigrationService {
       this.migrationStatus.status === Status.NOT_STARTED ||
       this.migrationStatus.status === Status.COMPLETE
     ) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.process();
-      this.migrationStatus = { status: Status.IN_PROGRESS };
+      try {
+        void this.process();
+      } catch (error) {
+        this.migrationStatus = {
+          status: Status.ERROR,
+          message: 'error processing the dashboard migration',
+        };
+      }
     }
   }
 
   public getMigrationStatus(): MigrationStatus {
+    // When migration is complete, set it back to NOT_STARTED state
+    if (this.migrationStatus.status === Status.COMPLETE) {
+      const oldStatus = this.migrationStatus;
+      this.migrationStatus = { status: Status.NOT_STARTED };
+      return oldStatus;
+    }
     return this.migrationStatus;
   }
 }

--- a/apps/core/src/migration/util/convertSiteWiseMonitorToApplicationDefinition.ts
+++ b/apps/core/src/migration/util/convertSiteWiseMonitorToApplicationDefinition.ts
@@ -1,0 +1,11 @@
+import { DashboardDefinition } from 'src/dashboards/entities/dashboard-definition.entity';
+
+export const convertSiteWiseMonitorToApplicationDefinition = (
+  sitewiseMonitorDashboardDefinition?: string,
+): DashboardDefinition => {
+  // TODO: add actual definition conversion
+  if (sitewiseMonitorDashboardDefinition) {
+    return { widgets: [] };
+  }
+  return { widgets: [] };
+};


### PR DESCRIPTION
# Description

* Adding the logic for fetching the SWM dashboards and creating application dashboards from them
* Updated UX after feedback to use flashbars instead of status indicators 
* TODOs 
   * Find a better way to dedupe the flashbars for migration so only 1 is shown at a time
   * Add more testing on the migration service after adding proper error handling 
   * Testing for pagination, I was having trouble getting it to work. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manually tested, unit tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
