### PR TITLE
feat: migration dashboard dedupe and testing

### DIFF
--- a/apps/client/src/data/migration.ts
+++ b/apps/client/src/data/migration.ts
@@ -8,7 +8,10 @@ export const MIGRATION_STATUS_QUERY_KEY = [...MIGRATION_QUERY_KEY, 'status'];
 
 export const MIGRATION_QUERY = {
   queryKey: MIGRATION_START_QUERY_KEY,
-  queryFn: dashboardMigration,
+  queryFn: async () => {
+    await dashboardMigration();
+    return {};
+  },
 };
 
 export const MIGRATION_STATUS_QUERY = {

--- a/apps/client/src/routes/dashboards/dashboards-index/components/migration.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/migration.tsx
@@ -17,7 +17,6 @@ export interface MigrationProps {
 }
 
 const Migration = (props: MigrationProps) => {
-  // TODO: handle more API errors once API is implemented
   const { data, isError } = useMigrationStatusQuery();
   const { refetch, isRefetching, isLoading } = useMigrationQuery();
   const emit = useEmitNotification();

--- a/apps/client/src/services/generated/services/MigrationService.ts
+++ b/apps/client/src/services/generated/services/MigrationService.ts
@@ -11,7 +11,7 @@ export class MigrationService {
    * @returns void
    * @throws ApiError
    */
-  public static migrationControllerMigration() {
+  public static migrationControllerMigration(): CancelablePromise<void> {
     return __request(OpenAPI, {
       method: 'POST',
       url: '/migration',

--- a/apps/core/src/dashboards/dto/update-dashboard.dto.ts
+++ b/apps/core/src/dashboards/dto/update-dashboard.dto.ts
@@ -7,4 +7,5 @@ export class UpdateDashboardDto extends OmitType(PartialType(Dashboard), [
   'id',
   'creationDate',
   'lastUpdateDate',
+  'sitewiseMonitorId',
 ] as const) {}

--- a/apps/core/src/dashboards/entities/dashboard.entity.ts
+++ b/apps/core/src/dashboards/entities/dashboard.entity.ts
@@ -5,6 +5,7 @@ import {
   IsString,
   Length,
   ValidateNested,
+  IsOptional,
 } from 'class-validator';
 
 import { DashboardDefinition } from './dashboard-definition.entity';
@@ -16,6 +17,7 @@ import {
 export type DashboardId = string;
 export type DashboardName = string;
 export type DashboardDescription = string;
+export type SiteWiseMonitorDashboardId = string;
 
 export class Dashboard {
   /**
@@ -50,5 +52,7 @@ export class Dashboard {
   @IsDateString()
   public readonly lastUpdateDate: string;
 
-  // TODO: Add SWM DashboardId
+  @IsString()
+  @IsOptional()
+  public readonly sitewiseMonitorId?: SiteWiseMonitorDashboardId;
 }

--- a/apps/core/src/migration/migration.controller.ts
+++ b/apps/core/src/migration/migration.controller.ts
@@ -11,7 +11,7 @@ export class MigrationController {
   @Post()
   @HttpCode(202)
   public migration() {
-    this.migrationService.migrate();
+    void this.migrationService.migrate();
   }
 
   @Get()

--- a/apps/core/src/migration/migration.e2e.spec.ts
+++ b/apps/core/src/migration/migration.e2e.spec.ts
@@ -15,15 +15,19 @@ import {
   ListDashboardsResponse,
   DescribeDashboardCommand,
   DescribeDashboardResponse,
+  InternalFailureException,
 } from '@aws-sdk/client-iotsitewise';
 
 import { mockClient } from 'aws-sdk-client-mock';
 import { MigrationService } from './migration.service';
 import { DashboardsService } from '../dashboards/dashboards.service';
 import { DashboardsModule } from '../dashboards/dashboards.module';
+import { MigrationStatus, Status } from './entities/migration-status.entity';
 
-const sitewiseMock = mockClient(IoTSiteWiseClient);
+import { ok } from '../types';
+import { DashboardSummary } from 'src/dashboards/entities/dashboard-summary.entity';
 
+const dashboardId = 'dashboardId';
 const testPortals = {
   portalSummaries: [
     {
@@ -45,15 +49,26 @@ const testProjects = {
 const testDashboards: ListDashboardsResponse = {
   dashboardSummaries: [
     {
-      id: 'dashboardId',
+      id: dashboardId,
       name: 'testDashboard',
       description: 'testDescription',
     },
   ],
 };
+const testApplicationDashboard = {
+  id: dashboardId,
+  name: 'testDashboard',
+  description: '',
+  creationDate: new Date().toString(),
+  lastUpdateDate: new Date().toString(),
+  definition: { widgets: [] },
+};
+const testApplicationDashboards: DashboardSummary[] = [
+  testApplicationDashboard,
+];
 const expectedDefinition = { widgets: [] };
 const testDashboard: DescribeDashboardResponse = {
-  dashboardId: 'testId',
+  dashboardId: dashboardId,
   dashboardArn: 'testArn',
   dashboardCreationDate: new Date(),
   dashboardDefinition: JSON.stringify(expectedDefinition),
@@ -63,7 +78,6 @@ const testDashboard: DescribeDashboardResponse = {
   projectId: 'testProjectId',
 };
 
-// TODO: Add pagination and error handling tests
 describe('MigrationModule', () => {
   let bearerToken = '';
   let app: NestFastifyApplication;
@@ -74,7 +88,39 @@ describe('MigrationModule', () => {
   let migrationStatusSpy: jest.SpyInstance;
   let createSpy: jest.SpyInstance;
 
-  beforeAll(async () => {
+  const sitewiseMock = mockClient(IoTSiteWiseClient);
+
+  const getStatus = async (): Promise<MigrationStatus> => {
+    const getResponse = await app.inject({
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
+      },
+      method: 'GET',
+      url: '/api/migration',
+    });
+
+    return JSON.parse(getResponse.payload) as unknown as MigrationStatus;
+  };
+
+  const waitForStatus = async (): Promise<MigrationStatus> => {
+    let status = await getStatus();
+
+    while (status.status === Status.IN_PROGRESS) {
+      // Wait a short amount of time to allow status setting to finish
+      await new Promise((r) => setTimeout(r, 100));
+      status = await getStatus();
+    }
+
+    return status;
+  };
+
+  beforeEach(async () => {
+    sitewiseMock.reset();
+    sitewiseMock.on(ListPortalsCommand).resolves(testPortals);
+    sitewiseMock.on(ListProjectsCommand).resolves(testProjects);
+    sitewiseMock.on(ListDashboardsCommand).resolves(testDashboards);
+    sitewiseMock.on(DescribeDashboardCommand).resolves(testDashboard);
+
     configureTestProcessEnv(process.env);
 
     const moduleRef = await Test.createTestingModule({
@@ -87,7 +133,19 @@ describe('MigrationModule', () => {
 
     migrateSpy = jest.spyOn(migrationService, 'migrate');
     migrationStatusSpy = jest.spyOn(migrationService, 'getMigrationStatus');
-    createSpy = jest.spyOn(dashboardService, 'create');
+    createSpy = jest
+      .spyOn(dashboardService, 'create')
+      .mockImplementation(() => {
+        return new Promise((resolve) => {
+          resolve(ok(testApplicationDashboard));
+        });
+      });
+
+    jest.spyOn(dashboardService, 'list').mockReturnValue(
+      new Promise((resolve) => {
+        resolve(ok([]));
+      }),
+    );
 
     app = moduleRef.createNestApplication<NestFastifyApplication>(
       new FastifyAdapter(),
@@ -106,15 +164,8 @@ describe('MigrationModule', () => {
     bearerToken = await getAccessToken();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
-  });
-
-  beforeEach(() => {
-    sitewiseMock.reset();
-    sitewiseMock.on(ListPortalsCommand).resolves({ portalSummaries: [] });
-    sitewiseMock.on(ListProjectsCommand).resolves({ projectSummaries: [] });
-    sitewiseMock.on(ListDashboardsCommand).resolves({ dashboardSummaries: [] });
   });
 
   describe('POST /api/migration HTTP/1.1', () => {
@@ -131,13 +182,7 @@ describe('MigrationModule', () => {
       expect(response.statusCode).toBe(202);
     });
 
-    test('call DashboardService create if SiteWise Monitor dashboards exist', async () => {
-      sitewiseMock.reset();
-      sitewiseMock.on(ListPortalsCommand).resolves(testPortals);
-      sitewiseMock.on(ListProjectsCommand).resolves(testProjects);
-      sitewiseMock.on(ListDashboardsCommand).resolves(testDashboards);
-      sitewiseMock.on(DescribeDashboardCommand).resolves(testDashboard);
-
+    test('calls DashboardService create if SiteWise Monitor dashboards exist and sets status to complete', async () => {
       const response = await app.inject({
         headers: {
           Authorization: `Bearer ${bearerToken}`,
@@ -151,8 +196,132 @@ describe('MigrationModule', () => {
         name: testDashboard.dashboardName,
         description: testDashboard.dashboardDescription,
         definition: expectedDefinition,
+        sitewiseMonitorId: testDashboard.dashboardId,
+      });
+
+      expect(response.statusCode).toBe(202);
+
+      const status = await waitForStatus();
+      expect(status).toEqual({ status: Status.COMPLETE });
+    });
+
+    test('sets status to complete when no SiteWise Monitor dashboards exist', async () => {
+      sitewiseMock.on(ListPortalsCommand).resolves(testPortals);
+      sitewiseMock.on(ListProjectsCommand).resolves(testProjects);
+      sitewiseMock
+        .on(ListDashboardsCommand)
+        .resolves({ dashboardSummaries: [] });
+      sitewiseMock.on(DescribeDashboardCommand).resolves(testDashboard);
+
+      const response = await app.inject({
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        method: 'POST',
+        url: '/api/migration',
+      });
+
+      expect(migrateSpy).toHaveBeenCalled();
+      expect(createSpy).not.toHaveBeenCalled();
+
+      expect(response.statusCode).toBe(202);
+
+      const status = await waitForStatus();
+      expect(status).toEqual({ status: Status.COMPLETE });
+    });
+
+    test('dedupe - does not create dashboards that have already been migrated', async () => {
+      jest.resetAllMocks();
+      migrateSpy = jest.spyOn(migrationService, 'migrate');
+      migrationStatusSpy = jest.spyOn(migrationService, 'getMigrationStatus');
+      createSpy = jest.spyOn(dashboardService, 'create').mockImplementation();
+      jest.spyOn(dashboardService, 'list').mockReturnValue(
+        new Promise((resolve) => {
+          resolve(ok(testApplicationDashboards));
+        }),
+      );
+
+      const response = await app.inject({
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        method: 'POST',
+        url: '/api/migration',
+      });
+
+      expect(migrateSpy).toHaveBeenCalled();
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(response.statusCode).toBe(202);
+    });
+
+    test('sets status to ERROR when there is an exception', async () => {
+      sitewiseMock.on(ListPortalsCommand).resolves(testPortals);
+      sitewiseMock.on(ListProjectsCommand).resolves(testProjects);
+      sitewiseMock.on(ListDashboardsCommand).resolves(testDashboards);
+      const errorMessage = 'Error calling SiteWise APIs';
+      sitewiseMock.on(DescribeDashboardCommand).rejects(
+        new InternalFailureException({
+          message: errorMessage,
+          $metadata: {},
+        }),
+      );
+
+      await app.inject({
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        method: 'POST',
+        url: '/api/migration',
+      });
+
+      const status = await waitForStatus();
+      expect(status).toEqual({ message: errorMessage, status: Status.ERROR });
+    });
+
+    test('handles paginated results in SiteWise API', async () => {
+      sitewiseMock
+        .on(ListPortalsCommand)
+        .resolvesOnce({
+          portalSummaries: testPortals.portalSummaries,
+          nextToken: 'token',
+        })
+        .resolves(testPortals);
+      sitewiseMock
+        .on(ListProjectsCommand)
+        .resolvesOnce({
+          projectSummaries: testProjects.projectSummaries,
+          nextToken: 'token',
+        })
+        .resolves(testProjects);
+      sitewiseMock
+        .on(ListDashboardsCommand)
+        .resolvesOnce({
+          dashboardSummaries: testDashboards.dashboardSummaries,
+          nextToken: 'token',
+        })
+        .resolves(testDashboards);
+      sitewiseMock.on(DescribeDashboardCommand).resolves(testDashboard);
+
+      const response = await app.inject({
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        method: 'POST',
+        url: '/api/migration',
       });
       expect(response.statusCode).toBe(202);
+
+      const status = await waitForStatus();
+
+      expect(migrateSpy).toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledWith({
+        name: testDashboard.dashboardName,
+        description: testDashboard.dashboardDescription,
+        definition: expectedDefinition,
+        sitewiseMonitorId: testDashboard.dashboardId,
+      });
+
+      expect(status).toEqual({ status: Status.COMPLETE });
     });
 
     test('returns 401 when request is unauthenticated', async () => {


### PR DESCRIPTION
# Description

* Added dedupe logic to check if dashboards have already been migrated and prevent migration if so
* Added optional SiteWiseMonitorDashboardId field to db/related objects in order to track which dashboards are migrated dashboards
* Adding better error handling for the migration service
* Adding pagination and error state tests for migration service

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual tests and migration e2e tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
