### PR TITLE
feat: migration parsing error handling

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/components/migration.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/migration.tsx
@@ -35,6 +35,7 @@ const Migration = (props: MigrationProps) => {
   }
 
   if (data?.status === Status.ERROR) {
+    props.onMigrationComplete();
     if (data.message) {
       emit(
         new ErrorNotification(

--- a/apps/core/src/migration/util/convertMonitorToAppDefinition.spec.ts
+++ b/apps/core/src/migration/util/convertMonitorToAppDefinition.spec.ts
@@ -78,9 +78,8 @@ describe('Dashboard definition conversion', () => {
         },
       ],
     };
-    const applicationDefinition = convertMonitorToAppDefinition(
-      JSON.stringify(lineChartDefinition),
-    );
+    const applicationDefinition =
+      convertMonitorToAppDefinition(lineChartDefinition);
     expect(applicationDefinition).toEqual(expectedDefinition);
   });
 });

--- a/apps/core/src/migration/util/convertMonitorToAppDefinition.ts
+++ b/apps/core/src/migration/util/convertMonitorToAppDefinition.ts
@@ -109,36 +109,26 @@ const convertProperties = (monitorMetrics?: MonitorMetric[]) => {
 };
 
 export const convertMonitorToAppDefinition = (
-  monitorDashboardDefinition?: string,
+  monitorDashboardDefinition: SiteWiseMonitorDashboardDefinition,
 ): DashboardDefinition => {
-  if (monitorDashboardDefinition) {
-    const definition = JSON.parse(
-      monitorDashboardDefinition,
-    ) as SiteWiseMonitorDashboardDefinition;
+  const newDashboardDefinition: DashboardDefinition = { widgets: [] };
 
-    if (definition.widgets) {
-      const newDashboardDefinition: DashboardDefinition = { widgets: [] };
+  if (monitorDashboardDefinition.widgets) {
+    for (const widget of monitorDashboardDefinition.widgets) {
+      const newAppWidget: DashboardWidget = {
+        type: convertType(widget.type),
+        id: widget.title,
+        x: convertX(widget.x),
+        y: convertY(widget.y),
+        z: 0,
+        width: convertWidth(widget.width),
+        height: convertHeight(widget.height),
+        properties: convertProperties(widget.metrics),
+      };
 
-      for (const widget of definition.widgets) {
-        const newAppWidget: DashboardWidget = {
-          type: convertType(widget.type),
-          id: widget.title,
-          x: convertX(widget.x),
-          y: convertY(widget.y),
-          z: 0,
-          width: convertWidth(widget.width),
-          height: convertHeight(widget.height),
-          properties: convertProperties(widget.metrics),
-        };
-
-        newDashboardDefinition.widgets.push(newAppWidget);
-      }
-
-      return newDashboardDefinition;
+      newDashboardDefinition.widgets.push(newAppWidget);
     }
-
-    return { widgets: [] };
   }
 
-  return { widgets: [] };
+  return newDashboardDefinition;
 };


### PR DESCRIPTION
# Description

* Following up on https://github.com/awslabs/iot-application/pull/1679 feedback to add an explicit catch for the JSON dashboard definition string parsing 
* I was trying to decide between returning dashboardId or dashboardName for any dashboards with parsing errors and went with name since that would be more useful for the customer to know which dashboards failed.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] e2e service test and manual testing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).


https://github.com/awslabs/iot-application/assets/66272633/a48a736d-8732-4021-b02d-444edfc2cced


