### PR TITLE
feat: migration threshold conversion

### DIFF
--- a/apps/core/src/migration/util/convertMonitorToAppDefinition.spec.ts
+++ b/apps/core/src/migration/util/convertMonitorToAppDefinition.spec.ts
@@ -34,14 +34,15 @@ describe('Dashboard definition conversion', () => {
     const expectedDefinition = {
       widgets: [
         {
-          type: 'line-scatter-chart',
-          id: 'Total Average Power',
+          type: 'xy-plot',
           x: 0,
           y: 0,
           z: 0,
-          width: 84,
-          height: 51,
+          width: 99,
+          height: 42,
           properties: {
+            title: 'Total Average Power',
+            thresholds: [],
             symbol: {
               style: 'filled-circle',
             },
@@ -80,6 +81,107 @@ describe('Dashboard definition conversion', () => {
     };
     const applicationDefinition =
       convertMonitorToAppDefinition(lineChartDefinition);
-    expect(applicationDefinition).toEqual(expectedDefinition);
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('converts Monitor annotations into Application thresholds', () => {
+    const color = '#5e87b5';
+    const comparisonOperator = 'LT';
+    const showValue = true;
+    const value = 100;
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [
+        {
+          type: 'sc-line-chart',
+          title: 'Total Average Power',
+          x: 0,
+          y: 0,
+          height: 3,
+          width: 3,
+          metrics: [
+            {
+              type: 'iotsitewise',
+              label: 'Total Average Power (Demo Wind Farm Asset)',
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+              dataType: 'DOUBLE',
+            },
+          ],
+          alarms: [],
+          properties: {
+            colorDataAcrossThresholds: true,
+          },
+          annotations: {
+            y: [
+              {
+                color,
+                comparisonOperator,
+                showValue,
+                value,
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const expectedDefinition = {
+      widgets: [
+        {
+          type: 'xy-plot',
+          x: 0,
+          y: 0,
+          z: 0,
+          width: 99,
+          height: 42,
+          properties: {
+            title: 'Total Average Power',
+            thresholds: [
+              {
+                color,
+                comparisonOperator,
+                value,
+                visible: showValue,
+              },
+            ],
+            symbol: {
+              style: 'filled-circle',
+            },
+            axis: {
+              yVisible: true,
+              xVisible: true,
+            },
+            line: {
+              connectionStyle: 'linear',
+              style: 'solid',
+            },
+            legend: {
+              visible: true,
+            },
+            queryConfig: {
+              source: 'iotsitewise',
+              query: {
+                properties: [],
+                assets: [
+                  {
+                    assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+                    properties: [
+                      {
+                        aggregationType: 'AVERAGE',
+                        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                        resolution: '1m',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    };
+    const applicationDefinition =
+      convertMonitorToAppDefinition(lineChartDefinition);
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
   });
 });

--- a/apps/core/src/migration/util/monitorDashboardDefinition.ts
+++ b/apps/core/src/migration/util/monitorDashboardDefinition.ts
@@ -2,8 +2,13 @@ export enum MonitorWidgetType {
   LineChart = 'sc-line-chart',
 }
 
+export interface MonitorTrend {
+  type: string;
+  color: string;
+}
+
 export interface MonitorAnalysis {
-  trends: string[];
+  trends?: string[]; // We don't currently support trend lines but Monitor does
 }
 
 export interface MonitorMetric {
@@ -16,8 +21,16 @@ export interface MonitorMetric {
   analysis?: MonitorAnalysis;
 }
 
+export interface MonitorAnnotation {
+  color: string;
+  comparisonOperator: string;
+  showValue: boolean;
+  value: number;
+}
+
 export interface MonitorAnnotations {
-  y: string[];
+  x?: MonitorAnnotation[];
+  y?: MonitorAnnotation[];
 }
 
 export interface MonitorProperties {
@@ -34,7 +47,7 @@ export interface MonitorWidget {
   properties?: MonitorProperties;
   metrics?: MonitorMetric[];
   annotations?: MonitorAnnotations;
-  alarms?: string[]; // We don't support alarms but Monitor does
+  alarms?: string[]; // We don't currently support alarms but Monitor does
 }
 
 export interface SiteWiseMonitorDashboardDefinition {


### PR DESCRIPTION
# Description

* Adding the conversion from SiteWise Monitor annotations to IoT Application thresholds
* I also changed the scaling value for the layout based on some testing. These new values match more closely.
* Switch `line-scatter-chart` to `xy-plot` 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added a test which validates the thresholds and did manual testing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

***Thresholds in Monitor and application:***

<img width="1726" alt="monitorannotation" src="https://github.com/awslabs/iot-application/assets/66272633/6d445200-0094-489c-a0d0-90bf3f6abd4f">
<img width="1726" alt="centurionthreshold" src="https://github.com/awslabs/iot-application/assets/66272633/0ca13177-8c51-4cee-bd7c-28ad55f163b3">

***Complex layout in Monitor and application:***

<img width="865" alt="monitorlayout" src="https://github.com/awslabs/iot-application/assets/66272633/4c4cdf30-0bf9-421d-abaa-7f272e956b25">
<img width="865" alt="centurionlayout" src="https://github.com/awslabs/iot-application/assets/66272633/10fb6dd2-23f6-419f-aa46-dd0e3ab1da05">

