### PR TITLE
chore: allow manual start on deployment GH workflows

### DIFF
--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -5,6 +5,7 @@ run-name: Deployment action initiated by ${{ github.actor }}
 on:
   pull_request:
     branches: [main, rc]
+  workflow_dispatch:
 
 # Ensures that only one deployment is in progress
 concurrency: ${{ github.workflow }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -5,6 +5,7 @@ run-name: Deployment action initiated by ${{ github.actor }}
 on:
   push:
     branches: [main, rc]
+  workflow_dispatch:
 
 # Ensures that only one deployment is in progress
 concurrency: ${{ github.workflow }}

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.438.0",
+    "@aws-sdk/client-iotsitewise": "^3.441.0",
     "@aws-sdk/lib-dynamodb": "^3.441.0",
     "@fastify/cookie": "^9.1.0",
     "@fastify/csrf-protection": "^6.4.1",


### PR DESCRIPTION
# Description

1. Allow manual start on deployment GH workflows; it enables to create the stack after cleanup
2. Also fixed the problem where Core service could not start due to missing module, `Error: Cannot find module '@aws-sdk/client-iotsitewise'`

# How Has This Been Tested?

pending [Deployment](https://github.com/awslabs/iot-application/actions/runs/6809991504/job/18517375927?pr=1696)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
