### PR TITLE
chore: adding groups to dependabot so we do not have a lot of open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 25
-
+    groups:
+      aws-sdk:
+        patterns:
+        - "@aws-sdk*"
+      tanstack:
+        patterns:
+          - "@tanstack*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
# Description

Adding groups to dependabot so we do not have a lot of open chore PRs.
grouping the following updates
1. aws-sdk
2. tanstack

Fixes # (issue)
Too many chore CRs 

## Type of change
workflow update

# How Has This Been Tested?
not yet

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
