### PR TITLE
chore: isolate main/rc branch deployment stacks

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -48,12 +48,12 @@ jobs:
           aws-region: us-west-2
 
       - name: Deploy CDK 🚀
-        run: yarn workspace cdk cdk deploy --all --require-approval never
+        run: yarn workspace cdk cdk deploy --all --require-approval never -c stackName=IotApp${{github.ref}}
 
       - name: Get App URL 🔗
         id: app_url
         run: |
-          app_url=$(aws cloudformation describe-stacks --stack-name IotApp --query "Stacks[0].Outputs[?OutputKey=='AppURL'].OutputValue" --output text)
+          app_url=$(aws cloudformation describe-stacks --stack-name IotApp${{github.ref}} --query "Stacks[0].Outputs[?OutputKey=='IotApp${{github.ref}}'].OutputValue" --output text)
           echo "app_url=$app_url" >> $GITHUB_OUTPUT
 
   test:


### PR DESCRIPTION
# Description

Currently, both `main` and `rc` commit changes are deployed to the same CloudFormation stack and overwriting the other branch changes.
This change isolates the changes by deploying to its corresponding CloudFormation stack.

# How Has This Been Tested?

stack name changes only, previous passing deployments/tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
