### PR TITLE
fix: deployment workflow CFN stack name

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 # Ensures that only one deployment is in progress
-concurrency: ${{ github.workflow }}
+concurrency: ${{ github.workflow }}-${{github.head_ref}}
 
 jobs:
   deploy:
@@ -48,12 +48,12 @@ jobs:
           aws-region: us-west-2
 
       - name: Deploy CDK 🚀
-        run: yarn workspace cdk cdk deploy --all --require-approval never -c stackName=IotApp${{github.ref}}
+        run: yarn workspace cdk cdk deploy --all --require-approval never -c stackName=IotApp-${{github.head_ref}}
 
       - name: Get App URL 🔗
         id: app_url
         run: |
-          app_url=$(aws cloudformation describe-stacks --stack-name IotApp${{github.ref}} --query "Stacks[0].Outputs[?OutputKey=='IotApp${{github.ref}}'].OutputValue" --output text)
+          app_url=$(aws cloudformation describe-stacks --stack-name IotApp-${{github.head_ref}} --query "Stacks[0].Outputs[?OutputKey=='IotApp${{github.head_ref}}'].OutputValue" --output text)
           echo "app_url=$app_url" >> $GITHUB_OUTPUT
 
   test:


### PR DESCRIPTION
# Description

Currently, deployment workflow name CloudFormation stack with suffix `github.ref` and it includes invalid character (`/`, e.g. `'refs/heads/main'`).

This PR fixes the problem by using `github.head_ref` for suffix (e.g. `main` or `rc`).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
