### PR TITLE
fix: deployment workflow CFN stack output key

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get App URL 🔗
         id: app_url
         run: |
-          app_url=$(aws cloudformation describe-stacks --stack-name IotApp-${{github.ref_name}} --query "Stacks[0].Outputs[?OutputKey=='IotApp${{github.ref_name}}'].OutputValue" --output text)
+          app_url=$(aws cloudformation describe-stacks --stack-name IotApp-${{github.ref_name}} --query "Stacks[0].Outputs[?OutputKey=='AppURL'].OutputValue" --output text)
           echo "app_url=$app_url" >> $GITHUB_OUTPUT
 
   test:


### PR DESCRIPTION
# Description

Previous, a typo replaced the correct output key, see [commit](https://github.com/awslabs/iot-application/commit/ac7effa412214f8b046f88d9b4ce031189707a7c)

# Testings

run `aws cloudformation describe-stacks --stack-name IotApp-main --query "Stacks[0].Outputs[?OutputKey=='AppURL'].OutputValue" --output text` and able to retrieve the application URL

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
