### PR TITLE
chore: upgrade Tanstack Query to v5

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -28,7 +28,7 @@
     "@cloudscape-design/design-tokens": "3.0.28",
     "@cloudscape-design/global-styles": "^1.0.15",
     "@iot-app-kit/dashboard": "^9.4.0",
-    "@tanstack/react-query": "^4.36.1",
+    "@tanstack/react-query": "^5.8.1",
     "aws-amplify": "^5.3.11",
     "cytoscape": "^3.26.0",
     "jotai": "^2.5.0",

--- a/apps/client/src/data/dashboards.ts
+++ b/apps/client/src/data/dashboards.ts
@@ -25,19 +25,25 @@ export function createDashboardQuery(id: Dashboard['id']) {
 }
 
 export async function invalidateDashboards() {
-  await queryClient.invalidateQueries(DASHBOARD_SUMMARIES_QUERY_KEY);
+  await queryClient.invalidateQueries({
+    queryKey: DASHBOARD_SUMMARIES_QUERY_KEY,
+  });
 }
 
 export async function invalidateDashboard(id: Dashboard['id']) {
-  await queryClient.invalidateQueries([...DASHBOARD_DETAILS_QUERY_KEY, { id }]);
+  await queryClient.invalidateQueries({
+    queryKey: [...DASHBOARD_DETAILS_QUERY_KEY, { id }],
+  });
 }
 
 export async function cancelDashboardsQueries() {
-  await queryClient.cancelQueries(DASHBOARD_SUMMARIES_QUERY_KEY);
+  await queryClient.cancelQueries({ queryKey: DASHBOARD_SUMMARIES_QUERY_KEY });
 }
 
 export async function cancelDashboardQueries(id: Dashboard['id']) {
-  await queryClient.cancelQueries([...DASHBOARD_DETAILS_QUERY_KEY, { id }]);
+  await queryClient.cancelQueries({
+    queryKey: [...DASHBOARD_DETAILS_QUERY_KEY, { id }],
+  });
 }
 
 export async function prefetchDashboards() {

--- a/apps/client/src/routes/dashboards/create/create-dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/create/create-dashboard-page.tsx
@@ -54,7 +54,7 @@ export function CreateDashboardPage() {
           variant="full-page"
           actions={
             <CreateDashboardFormActions
-              isLoading={createDashboardMutation.isLoading}
+              isLoading={createDashboardMutation.isPending}
             />
           }
           errorText={getFormErrorText()}

--- a/apps/client/src/routes/dashboards/dashboard/hooks/use-dashboard-query.ts
+++ b/apps/client/src/routes/dashboards/dashboard/hooks/use-dashboard-query.ts
@@ -1,26 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
-import invariant from 'tiny-invariant';
 
 import { createDashboardQuery } from '~/data/dashboards';
 import { isFatal } from '~/helpers/predicates/is-fatal';
-import { isNotFatal } from '~/helpers/predicates/is-not-fatal';
-import { useEmitNotification } from '~/hooks/notifications/use-emit-notification';
-import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
 
 import type { Dashboard } from '~/services';
 
 export function useDashboardQuery(dashboardId: Dashboard['id']) {
-  const emit = useEmitNotification();
-
   return useQuery({
     ...createDashboardQuery(dashboardId),
-    useErrorBoundary: isFatal,
-    onError: (error) => {
-      invariant(
-        isNotFatal(error),
-        'Expected fatal error to be handled by error boundary',
-      );
-      emit(new GenericErrorNotification(error));
-    },
+    throwOnError: isFatal,
   });
 }

--- a/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/delete-dashboard-modal.tsx
@@ -123,7 +123,7 @@ export function DeleteDashboardModal(props: DeleteDashboardModalProps) {
                 disabled={!isValid}
                 variant="primary"
                 className="btn-custom-primary"
-                loading={mutation.isLoading}
+                loading={mutation.isPending}
                 onClick={() => {
                   void handleSubmit(() => {
                     handleDelete();

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -13,6 +13,7 @@ import { BaseNavigationDetail } from '@cloudscape-design/components/internal/eve
 import { Box } from '@cloudscape-design/components';
 import ContentLayout from '@cloudscape-design/components/content-layout';
 import { DevTool } from '@hookform/devtools';
+import { useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import type { FormatDateOptions } from 'react-intl';
@@ -29,10 +30,12 @@ import { isJust } from '~/helpers/predicates/is-just';
 import { useApplication } from '~/hooks/application/use-application';
 import { useDashboardsQuery } from './hooks/use-dashboards-query';
 import { useDeleteModalVisibility } from './hooks/use-delete-modal-visibility';
+import { useEmitNotification } from '~/hooks/notifications/use-emit-notification';
 import { usePartialUpdateDashboardMutation } from './hooks/use-partial-update-dashboard-mutation';
 import { useTablePreferences } from './hooks/use-table-preferences';
 import { $Dashboard, DashboardSummary } from '~/services';
 import { setDashboardEditMode } from '~/store/viewMode';
+import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
 
 import './styles.css';
 import { Features, featureEnabled } from '~/helpers/featureFlag/featureFlag';
@@ -55,6 +58,13 @@ export function DashboardsIndexPage() {
 
   const [preferences, setPreferences] = useTablePreferences();
   const dashboardsQuery = useDashboardsQuery();
+  const emitNotification = useEmitNotification();
+
+  useEffect(() => {
+    if (dashboardsQuery.isError) {
+      emitNotification(new GenericErrorNotification(dashboardsQuery.error));
+    }
+  }, [dashboardsQuery.error, dashboardsQuery.isError, emitNotification]);
 
   const {
     actions,

--- a/apps/client/src/routes/dashboards/dashboards-index/hooks/use-dashboards-query.ts
+++ b/apps/client/src/routes/dashboards/dashboards-index/hooks/use-dashboards-query.ts
@@ -1,19 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import invariant from 'tiny-invariant';
 
 import { DASHBOARDS_QUERY } from '~/data/dashboards';
-import { isApiError } from '~/helpers/predicates/is-api-error';
-import { useEmitNotification } from '~/hooks/notifications/use-emit-notification';
-import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
 
 export function useDashboardsQuery() {
-  const emit = useEmitNotification();
-
   return useQuery({
     ...DASHBOARDS_QUERY,
-    onError: (error) => {
-      invariant(isApiError(error));
-      emit(new GenericErrorNotification(error));
-    },
   });
 }

--- a/apps/client/src/routes/dashboards/dashboards-index/hooks/use-migration-status-query.ts
+++ b/apps/client/src/routes/dashboards/dashboards-index/hooks/use-migration-status-query.ts
@@ -6,6 +6,6 @@ export function useMigrationStatusQuery() {
     ...MIGRATION_STATUS_QUERY,
     refetchInterval: 2000,
     staleTime: 0,
-    cacheTime: 0,
+    gcTime: 0,
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9965,6 +9965,11 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.36.1.tgz#79f8c1a539d47c83104210be2388813a7af2e524"
   integrity sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==
 
+"@tanstack/query-core@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.8.1.tgz#5215a028370d9b2f32e83787a0ea119e2f977996"
+  integrity sha512-Y0enatz2zQXBAsd7XmajlCs+WaitdR7dIFkqz9Xd7HL4KV04JOigWVreYseTmNH7YFSBSC/BJ9uuNp1MAf+GfA==
+
 "@tanstack/query-devtools@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.1.0.tgz#ad7e88a4e7e0813bc00a25f0a9284d22990fe204"
@@ -9977,13 +9982,20 @@
   dependencies:
     "@tanstack/query-devtools" "5.1.0"
 
-"@tanstack/react-query@^4.29.15", "@tanstack/react-query@^4.36.1":
+"@tanstack/react-query@^4.29.15":
   version "4.36.1"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.36.1.tgz#acb589fab4085060e2e78013164868c9c785e5d2"
   integrity sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==
   dependencies:
     "@tanstack/query-core" "4.36.1"
     use-sync-external-store "^1.2.0"
+
+"@tanstack/react-query@^5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.8.1.tgz#22a122016e23a39acd90341954a895980ec21ade"
+  integrity sha512-YMagxS8iNPOLg0pK6WOjdSDlAvWKOf69udLOwQrBVmkC2SRLNLko7elo5Ro3ptlJkXvTVHidxC/h5KGi5bH1XQ==
+  dependencies:
+    "@tanstack/query-core" "5.8.1"
 
 "@testing-library/dom@^9.0.0":
   version "9.2.0"


### PR DESCRIPTION
# Description

This change upgrades our version of Tanstack Query from v4 to v5 following the official migration guide https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5. No functional changes were introduced.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
