### PR TITLE
chore: calm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,10 @@ updates:
     directory: /
     versioning-strategy: increase
     schedule:
-      interval: daily
-    open-pull-requests-limit: 25
+      interval: weekly
+    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
# Description

This change reduces the frequency and magnitude of dependabot updates from daily to weekly and 25 to 10, respectively.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
