### PR TITLE
feat: migration kpi,status grid support

### DIFF
--- a/apps/core/src/migration/README.md
+++ b/apps/core/src/migration/README.md
@@ -3,3 +3,26 @@
 `MigrationModule` extends Core with the `/migration` REST API.
 
 This module is for an API for converting SiteWise Monitor dashboards to IoT Application dashboards.
+
+# Dashboard definition conversion
+
+This service takes customer's SiteWise Monitor dashboard definitions and converts them to IoT Application dashboard definitions. There are some important differences between the two dashboard definitions that can make this conversion complicated.
+
+### Feature differences
+* SiteWise Monitor supports an alarms feature, while IoT Application currently does not
+* KPI and Status Grid in SiteWise Monitor support multiple datastreams per widget, in IoT Application we support one datastream per widget
+* There is a different layout system in each application
+* Colors are different between applications
+
+### KPI and Status Grid Differences
+The logic to convert KPI and Status Grid widgets from SiteWise Monitor to IoT Application is complicated because there is a one-to-many relationship from SiteWise Monitor to IoT Application widgets and feature differences. 
+
+In Monitor, as datastreams are added to a KPI/Grid widget, Monitor automatically resizes these sub-widgets to fit within the bounds of the containing widget. If the screen space is filled, a scrollbar is added and customers can scroll to view all their datastreams within the single KPI/Grid widget. These features do not exist in this IoT Application, so the service attempts to convert the definitions in a way that maintain these properties and match closely visually.
+
+The conversion process follows this logic:
+* When there are few (relative to the total size of the containing KPI/Grid widget) sub-widgets, scale them to fit within the size of the containg widget. For example if the Monitor KPI widget is a 9x9 grid, and there is 1 sub-widget, make this sub-widgets size 9x9. If there is 2 sub-widgets, divide this in half, etc. up until the minimim size values.
+* When there are many sub-widgets, use the minimum size value and lay them out in rows/columns within the bounds of the containing widget. Because we don't support a scrolling widget, if the Monitor widget has so many sub-widgets that there is a scrollbar, the IoT Applications will overflow and may overlap with other widgets.
+
+# Single-threaded execution
+
+This service relies on NestJS's usage of singleton service instances and uses local class variables for storing status. If we wish to run this application in a multi-threaded or multi-container environment we would need to update how it stores status to consider parallel execution.

--- a/apps/core/src/migration/service/convert-monitor-to-app-definition.spec.ts
+++ b/apps/core/src/migration/service/convert-monitor-to-app-definition.spec.ts
@@ -31,14 +31,19 @@ const createMonitorChartWidget = (
 const createApplicationChartDefinition = (
   widgetType: string,
   properties: object,
+  height = 41.5,
+  width = 98.5,
+  x = 0,
+  y = 0,
+  z = 0,
 ) => {
   return {
     type: widgetType,
-    x: 0,
-    y: 0,
-    z: 0,
-    width: 99,
-    height: 42,
+    x,
+    y,
+    z,
+    width,
+    height,
     properties,
   };
 };
@@ -387,6 +392,177 @@ describe('Dashboard definition conversion', () => {
     };
     const expectedDefinition = {
       widgets: [createApplicationChartDefinition('table', expectedProperties)],
+    };
+    const applicationDefinition =
+      convertMonitorToAppDefinition(lineChartDefinition);
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor KPI widget into an application KPI', () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const kpiDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.Kpi, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [createApplicationChartDefinition('kpi', expectedProperties)],
+    };
+    const applicationDefinition = convertMonitorToAppDefinition(kpiDefinition);
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a SiteWise Monitor KPI widget with many properties into many application KPIs', () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const kpiDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.Kpi, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          13.5,
+          32.5,
+          0,
+          0,
+          0,
+        ),
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          13.5,
+          32.5,
+          33,
+          0,
+          1,
+        ),
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          13.5,
+          32.5,
+          66,
+          0,
+          2,
+        ),
+      ],
+    };
+    const applicationDefinition = convertMonitorToAppDefinition(kpiDefinition);
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor status grid widget into an application status widget', () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [
+        createMonitorChartWidget(MonitorWidgetType.StatusGrid, metrics),
+      ],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [createApplicationChartDefinition('status', expectedProperties)],
     };
     const applicationDefinition =
       convertMonitorToAppDefinition(lineChartDefinition);


### PR DESCRIPTION
# Description

* Adding support for KPI and status grid conversion
* There are some differences between Monitor and this application with how the widgets are handled
   * In Monitor, KPI or status grid widget is one widget that creates many sub widgets for each property added
   * In Application, one property corresponds to one KPI or status widget
   * So we need to convert each KPI/Status grid from Monitor into many KPI/Status widgets (one-to-many relationship)
* The conversion isn't perfect but I tried to best match visually, see attached screenshots.
   * Monitor uses a grid system where each square in a grid has a value of 1 in the x,y,width,height system. So when doing the conversion I am laying out the KPI widgets in a way that follow that system, then converting out of that system into the application values (a 1x1 monitor square is similar to ~ 33x14 cells in the application). 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit and manual tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

## KPI

<img width="1725" alt="monitorkpi" src="https://github.com/awslabs/iot-application/assets/66272633/0045e901-4ccc-45c5-8c34-2cba57c5173a">
<img width="1727" alt="centurionkpi" src="https://github.com/awslabs/iot-application/assets/66272633/dd883a8a-0e10-455a-9779-dbbce2b2a7b0">

<img width="1726" alt="monitorkpi2" src="https://github.com/awslabs/iot-application/assets/66272633/23da65e2-c70e-42a8-b0a5-e5701b761f8c">
<img width="1727" alt="centurionkpi2" src="https://github.com/awslabs/iot-application/assets/66272633/02593c25-4b36-42d2-b81b-69bc6f527da6">

<img width="1728" alt="monitorkpi3" src="https://github.com/awslabs/iot-application/assets/66272633/8fdefcf1-bbde-49fc-9577-c7f3286c3323">
<img width="1723" alt="centurionkpi3" src="https://github.com/awslabs/iot-application/assets/66272633/ab99364e-db4a-433f-ba4f-5d50ce09d473">

<img width="865" alt="monitorkpi5" src="https://github.com/awslabs/iot-application/assets/66272633/3b661e54-3c4a-42a8-a88c-7af5fe6c2a92">
<img width="1727" alt="centurionkpi5" src="https://github.com/awslabs/iot-application/assets/66272633/08ca2665-f82e-4ffa-929e-207c5f973918">


## Status

<img width="865" alt="monitorgrid" src="https://github.com/awslabs/iot-application/assets/66272633/75dde2b3-163f-4224-ac51-05857b425fa0">
<img width="1726" alt="centuriongrid" src="https://github.com/awslabs/iot-application/assets/66272633/806b91ca-58e9-4411-b75d-b46dd4521e08">

<img width="1724" alt="monitorgrid2" src="https://github.com/awslabs/iot-application/assets/66272633/31483f80-b46c-4487-a420-a7b628532c9c">
<img width="1726" alt="centuriongrid2" src="https://github.com/awslabs/iot-application/assets/66272633/fd4643f8-c31a-4386-8d70-c231248fd2a7">
