### PR TITLE
fix: handled deadlinks #1754

### DIFF
--- a/apps/client/src/routes/dashboards/create/components/dashboard-description-field.tsx
+++ b/apps/client/src/routes/dashboards/create/components/dashboard-description-field.tsx
@@ -8,7 +8,6 @@ import { $Dashboard } from '~/services';
 import type { Control } from 'react-hook-form';
 import { CreateDashboardFormValues } from '../types/create-dashboard-form-values';
 import { isJust } from '~/helpers/predicates/is-just';
-import { Link } from '@cloudscape-design/components';
 
 interface DashboardDescriptionFieldProps {
   control: Control<CreateDashboardFormValues>;
@@ -48,7 +47,6 @@ export function DashboardDescriptionField(
             defaultMessage: 'Description',
             description: 'create dashboard form description label',
           })}
-          info={<Link variant="info">Info</Link>}
           constraintText={intl.formatMessage(
             {
               defaultMessage: 'Description must be fewer than 512 characters.',

--- a/apps/client/src/routes/dashboards/create/components/dashboard-name-field.tsx
+++ b/apps/client/src/routes/dashboards/create/components/dashboard-name-field.tsx
@@ -8,7 +8,6 @@ import { $Dashboard } from '~/services';
 import type { Control } from 'react-hook-form';
 import type { CreateDashboardFormValues } from '../types/create-dashboard-form-values';
 import { isJust } from '~/helpers/predicates/is-just';
-import { Link } from '@cloudscape-design/components';
 
 interface DashboardNameFieldProps {
   control: Control<CreateDashboardFormValues>;
@@ -44,7 +43,6 @@ export function DashboardNameField(props: DashboardNameFieldProps) {
             defaultMessage: 'Name',
             description: 'create dashboard form name label',
           })}
-          info={<Link variant="info">Info</Link>}
           constraintText={intl.formatMessage(
             {
               defaultMessage:

--- a/apps/client/src/routes/dashboards/dashboards-index/components/getting-started.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/getting-started.tsx
@@ -83,7 +83,7 @@ const GettingStarted = () => {
       headerInfo={
         <Link
           variant="info"
-          href="https://github.com/awslabs/iot-application/blob/main/docs/user-guide.md"
+          href="https://github.com/awslabs/iot-application/blob/main/userguide/README.md"
         >
           <FormattedMessage defaultMessage="Info" description="Info link" />
         </Link>


### PR DESCRIPTION
removed the info links from create dashboard and checked for the unwanted links but didn't find any.

[screen-capture (2).webm](https://github.com/awslabs/iot-application/assets/65999096/b81b2221-645a-497d-9486-382aaa46de4c)
