### PR TITLE
fix: migration fix sitewise sdk creds in deployed app

### DIFF
--- a/apps/core/src/migration/service/migration.service.ts
+++ b/apps/core/src/migration/service/migration.service.ts
@@ -29,29 +29,11 @@ export class MigrationService {
   private parsingErrors: Error[] = [];
 
   private sitewise = new IoTSiteWiseClient({
-    credentials: {
-      accessKeyId: this.getAccessKey(),
-      secretAccessKey: this.getSecretKey(),
-    },
     region: this.getRegion(),
   });
 
   private getRegion() {
     return process.env.AWS_REGION;
-  }
-
-  private getAccessKey() {
-    if (process.env.AWS_ACCESS_KEY_ID) {
-      return process.env.AWS_ACCESS_KEY_ID;
-    }
-    return '';
-  }
-
-  private getSecretKey() {
-    if (process.env.AWS_SECRET_ACCESS_KEY) {
-      return process.env.AWS_SECRET_ACCESS_KEY;
-    }
-    return '';
   }
 
   private async getPortals(): Promise<PortalSummary[]> {


### PR DESCRIPTION
# Description

* Before this change, if the application is deployed to the cloud, the sitewise sdk won't work for the migration APIs (`The security token included in the request is invalid`) because of trying to access the credentials through env variables like `process.env.AWS_ACCESS_KEY_ID`
* This change removes the credentials object because the aws sdks will automatically get the credentials from the node env and credentials are provided by app runner as described [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apprunner-service-instanceconfiguration.html#cfn-apprunner-service-instanceconfiguration-instancerolearn). I tested this in the deployed app and it works correctly.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manually testing deployed version

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
