### PR TITLE
fix: hide footer if viewing a dashboard

### DIFF
--- a/apps/client/src/layout/components/footer/footer.tsx
+++ b/apps/client/src/layout/components/footer/footer.tsx
@@ -7,8 +7,11 @@ import {
   spaceScaledL,
 } from '@cloudscape-design/design-tokens';
 import './footer.css';
+import { useParams } from 'react-router-dom';
 
 export const Footer = () => {
+  const params = useParams();
+
   const footerStyle = {
     fontSize: spaceScaledS,
     color: colorBackgroundControlDefault,
@@ -22,6 +25,7 @@ export const Footer = () => {
       id="app-footer"
       className="dashboard-footer-container"
       data-testid="footer-component"
+      hidden={!!params.dashboardId}
     >
       <div data-testid="copy-right" className="dashboard-footer-right-content">
         <FormattedMessage


### PR DESCRIPTION
# Description

footer: 
<img width="1000" alt="image" src="https://github.com/awslabs/iot-application/assets/28601414/68ce2f8b-5d4a-4666-b017-cca5681e487d">


no footer: 
<img width="1000" alt="image" src="https://github.com/awslabs/iot-application/assets/28601414/9f430eb3-c71d-4399-8e6c-7eca81e9c758">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] dashboard in edit mode hides the footer
- [ ] dashboard in view mode hides the footer
- [ ] going to the home page shows the footer

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
