### PR TITLE
fix: cross reference stack build error

### DIFF
--- a/cdk/lib/auth/auth-stack.ts
+++ b/cdk/lib/auth/auth-stack.ts
@@ -1,4 +1,4 @@
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import {
   CfnIdentityPool,
   CfnIdentityPoolRoleAttachment,
@@ -8,7 +8,7 @@ import {
 import { FederatedPrincipal, PolicyStatement, Role } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
-export interface AuthStackProps {
+export interface AuthStackProps extends StackProps {
   readonly applicationName: string;
   readonly logGroupArn: string;
 }
@@ -19,7 +19,7 @@ export class AuthStack extends Stack {
   readonly userPoolClient: UserPoolClient;
 
   constructor(scope: Construct, id: string, props: AuthStackProps) {
-    super(scope, id);
+    super(scope, id, props);
 
     const { applicationName, logGroupArn } = props;
 

--- a/cdk/lib/iot-application-stack.ts
+++ b/cdk/lib/iot-application-stack.ts
@@ -17,7 +17,11 @@ export class IotApplicationStack extends Stack {
       userPool: { userPoolId },
       userPoolClient: { userPoolClientId },
       identityPool: { ref: identityPoolId },
-    } = new AuthStack(this, 'Auth', { applicationName: id, logGroupArn });
+    } = new AuthStack(this, 'Auth', {
+      applicationName: id,
+      logGroupArn,
+      ...props,
+    });
 
     const {
       resourceTable: { tableArn, tableName },


### PR DESCRIPTION
# Description
* Right now, if I try to deploy the application, I get an error `Stack "IotApp/Core" cannot reference {IotApp/Auth/IdentityPool[Ref]} in stack "IotApp/Auth". Cross stack references are only supported for stacks deployed to the same account or between nested stacks and their parent stack`
* It looks like the issue is not passing the props to the `super` call within the auth stack. After adding this call, the cdk build succeeds 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Was able to deploy the app after this change when I previously couldn't 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
