### PR TITLE
fix: make all cdk stacks call super with props arg

### DIFF
--- a/cdk/lib/database/database-stack.ts
+++ b/cdk/lib/database/database-stack.ts
@@ -10,7 +10,7 @@ import { Construct } from 'constructs';
 export class DatabaseStack extends Stack {
   readonly resourceTable: Table;
 
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props: StackProps) {
     super(scope, id, props);
 
     this.resourceTable = new Table(this, 'ResourceTable', {

--- a/cdk/lib/iot-application-stack.ts
+++ b/cdk/lib/iot-application-stack.ts
@@ -6,12 +6,12 @@ import { DatabaseStack } from './database/database-stack';
 import { LoggingStack } from './logging/logging-stack';
 
 export class IotApplicationStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props: StackProps) {
     super(scope, id, props);
 
     const {
       logGroup: { logGroupArn },
-    } = new LoggingStack(this, 'Logging', { applicationName: id });
+    } = new LoggingStack(this, 'Logging', { applicationName: id, ...props });
 
     const {
       userPool: { userPoolId },

--- a/cdk/lib/logging/logging-stack.ts
+++ b/cdk/lib/logging/logging-stack.ts
@@ -1,8 +1,8 @@
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 
-export interface LoggingStackProps {
+export interface LoggingStackProps extends StackProps {
   readonly applicationName: string;
 }
 
@@ -10,7 +10,7 @@ export class LoggingStack extends Stack {
   readonly logGroup: LogGroup;
 
   constructor(scope: Construct, id: string, props: LoggingStackProps) {
-    super(scope, id);
+    super(scope, id, props);
 
     const { applicationName } = props;
 


### PR DESCRIPTION
# Description

* We should always call super with the props argument for cdk stacks as recommended, this PR ensures we're doing this in all our stacks

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- 
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] application builds

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
