### PR TITLE
chore: added JSON access log under auth guard

### DIFF
--- a/apps/core/src/auth/cognito-jwt-auth.guard.ts
+++ b/apps/core/src/auth/cognito-jwt-auth.guard.ts
@@ -58,14 +58,16 @@ export class CognitoJwtAuthGuard implements CanActivate {
 
     try {
       const httpRequest = context.switchToHttp().getRequest<HttpRequest>();
-      const { url } = httpRequest;
 
-      const { sub } = await this.config.cognitoJwtVerifier.verify(
+      const { sub: userId } = await this.config.cognitoJwtVerifier.verify(
         this.getBearerToken(httpRequest),
       );
-      this.logger.log(
-        `User ID "${sub}" authorized to ${controllerName}.${handlerName} (url: "${url}")`,
-      );
+
+      this.logUserAccess({
+        controllerName,
+        handlerName,
+        userId,
+      });
 
       return true;
     } catch (e) {
@@ -82,5 +84,24 @@ export class CognitoJwtAuthGuard implements CanActivate {
     const authorization = httpRequest.headers?.authorization ?? '';
 
     return authorization.replace(/^Bearer /, '');
+  }
+
+  private logUserAccess({
+    controllerName,
+    handlerName,
+    userId,
+  }: {
+    controllerName: string;
+    handlerName: string;
+    userId: string;
+  }) {
+    this.logger.log(
+      `User ID "${userId}" authorized to ${controllerName}.${handlerName}`,
+    );
+    this.logger.log({
+      controllerName,
+      handlerName,
+      userId,
+    });
   }
 }


### PR DESCRIPTION
# Description

This PR added a new log under auth guard to record authorization event in a JSON format. This JSON format allows IT admin to gather the unique user count with log insight query.

# How Has This Been Tested?

deployed to AWS Cloud and validated the log, example

```
{
    "level": 30,
    "time": 1701242102409,
    "pid": 1,
    "hostname": "xxx", (redacted)
    "reqId": "fc4d5635-d56b-4609-9896-51126a5ed5fb",
    "context": "CognitoJwtAuthGuard",
    "controllerName": "DashboardsController",
    "handlerName": "list",
    "userId": "xxx" (redacted)
}
```

IT admin can gather the unique user count with the log insight query, example:

**CloudWatch Logs Insights**    
region: us-west-2    
log-group-names: /aws/apprunner/ServiceXxx/Xxx/application (redacted)
start-time: -3600s    
end-time: 0s    
query-string:
  ```
  fields @message
| filter context = "CognitoJwtAuthGuard"
| stats count_distinct(userId)
  ```
---
| count_distinct(userId) |
| --- |
| 2 |
---

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
