### PR TITLE
fix: bulk delete of dashboards is not possible

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -249,7 +249,7 @@ export function DashboardsIndexPage() {
               actions={
                 <SpaceBetween direction="horizontal" size="xs">
                   <Button
-                    disabled={selectedItems.length !== 1}
+                    disabled={selectedItems.length === 0}
                     onClick={() => setIsDeleteModalVisible(true)}
                   >
                     <FormattedMessage


### PR DESCRIPTION
# Description

Issue: #1805 
Removed the condition to enable the delete button for bulk dashboards

## Type of change

https://github.com/awslabs/iot-application/assets/139960352/a39247d8-59a2-48ea-bf12-b09413d0f767



## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
