### PR TITLE
fix: remove project structure link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # IoT dashboard application built with IoT App Kit
 
-![Project Structure](./images/dashboard.png)
-
 The IoT dashboard application is an easy-to-use tool designed for businesses and individuals who need to keep track of their IoT devices and data. By creating and managing custom dashboards, you can effortlessly monitor your IoT devices and their data in real-time, connecting to your AWS IoT SiteWise data.
 
 Whether you're in manufacturing, logistics, energy, or other industries relying on IoT devices, the application can help you address specific challenges such as tracking equipment performance, optimizing operational efficiency, and making data-driven decisions.


### PR DESCRIPTION
# Description

This change removes the link to the project structure in the README. The link is broken as it was intended to be removed entirely.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
