### PR TITLE
fix: isolate PR deployment workflow by source branch

### DIFF
--- a/.github/workflows/deployment-cleanup-pr.yml
+++ b/.github/workflows/deployment-cleanup-pr.yml
@@ -1,0 +1,56 @@
+name: Deployment Cleanup PR
+
+run-name: PR Deployment Cleanup action initiated by ${{ github.actor }}
+
+on:
+  pull_request:
+    branches: [main, rc]
+    types: [ closed ]
+
+jobs:
+  cleanup-deploy-pr:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed to interact with GitHub's OIDC Token endpoint
+      contents: read
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install Java 🔧
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+
+      - name: Install Node.js 🔧
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install Dependencies 🔩
+        run: yarn install --frozen-lockfile
+
+      - name: Configure AWS credentials 🔑
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
+          aws-region: us-west-2
+
+      # Destory Application stack before other stacks to prevent failure due to in use Export by dependencies
+      # since CDK is not able to track the stack deployment order: https://github.com/aws/aws-cdk/issues/26491
+      - name: Destory Application Stack 🎯
+        run: yarn workspace cdk cdk destroy IotApp-${{ github.head_ref }} --force -c stackName=IotApp-${{ github.head_ref }}
+
+      # Destory Core stack before other stacks to prevent failure due to in use Export by dependencies
+      # since CDK is not able to track the stack deployment order: https://github.com/aws/aws-cdk/issues/26491
+      - name: Destory Core Stack 🎯
+        run: yarn workspace cdk cdk destroy IotApp-${{ github.head_ref }}/Core --force -c stackName=IotApp-${{ github.head_ref }}
+
+      - name: Destory CDK 💥
+        run: yarn workspace cdk cdk destroy --all --force -c stackName=IotApp-${{ github.head_ref }}

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -5,10 +5,9 @@ run-name: Deployment action initiated by ${{ github.actor }}
 on:
   pull_request:
     branches: [main, rc]
-  workflow_dispatch:
 
 # Ensures that only one deployment is in progress
-concurrency: ${{ github.workflow }}
+concurrency: ${{ github.workflow }}-${{ github.head_ref }}
 
 jobs:
   deploy-pr:
@@ -48,16 +47,43 @@ jobs:
           aws-region: us-west-2
 
       - name: Deploy CDK 🚀
-        run: yarn workspace cdk cdk deploy -c stackName=IotAppPr --all --require-approval never
+        run: yarn workspace cdk cdk deploy --all --require-approval never -c stackName=IotApp-${{ github.head_ref }} -c cleanupRetainedResources=true
 
       - name: Get App URL 🔗
         id: app_url
         run: |
-          app_url=$(aws cloudformation describe-stacks --stack-name IotAppPr --query "Stacks[0].Outputs[?OutputKey=='AppURL'].OutputValue" --output text)
+          app_url=$(aws cloudformation describe-stacks --stack-name IotApp-${{ github.head_ref }} --query "Stacks[0].Outputs[?OutputKey=='AppURL'].OutputValue" --output text)
           echo "app_url=$app_url" >> $GITHUB_OUTPUT
 
-  test-pr:
+  create-test-user-pr:
     needs: deploy-pr
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed to interact with GitHub's OIDC Token endpoint
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials 🔑
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
+          aws-region: us-west-2
+
+      - name: Get User Pool ID 🎱
+        run: |
+          userpool_id=$(aws cloudformation describe-stacks --stack-name IotApp-${{ github.head_ref }} --query "Stacks[0].Outputs[?OutputKey=='UserPoolId'].OutputValue" --output text)
+          echo "userpool_id=$userpool_id" >> "$GITHUB_ENV"
+
+      - name: Create User 🪪
+        continue-on-error: true # the user could be created already by previous runs
+        run: aws cognito-idp admin-create-user --user-pool-id "$userpool_id" --username test-user
+
+      - name: Set User Password 🔑
+        run: aws cognito-idp admin-set-user-password --permanent --user-pool-id "$userpool_id" --username test-user --password ${{ secrets.DEPLOYMENT_PR_USER_PASSWORD }}
+
+  test-pr:
+    needs: [deploy-pr, create-test-user-pr]
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import { App } from 'aws-cdk-lib';
+import { App, RemovalPolicy } from 'aws-cdk-lib';
 import { IotApplicationStack } from '../lib/iot-application-stack';
 
 const app = new App();
 const stackName = app.node.tryGetContext('stackName') as string;
+const cleanupRetainedResources = app.node.tryGetContext(
+  'cleanupRetainedResources',
+) as boolean;
+const removalPolicyOverride = cleanupRetainedResources
+  ? RemovalPolicy.DESTROY
+  : undefined;
+
 new IotApplicationStack(app, stackName, {
+  removalPolicyOverride,
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -17,6 +17,7 @@
     ]
   },
   "context": {
+    "cleanupRetainedResources": false,
     "stackName": "IotApp",
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,

--- a/cdk/lib/auth/auth-stack.ts
+++ b/cdk/lib/auth/auth-stack.ts
@@ -1,4 +1,4 @@
-import { Stack, StackProps } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import {
   CfnIdentityPool,
   CfnIdentityPoolRoleAttachment,
@@ -11,6 +11,7 @@ import { Construct } from 'constructs';
 export interface AuthStackProps extends StackProps {
   readonly applicationName: string;
   readonly logGroupArn: string;
+  readonly removalPolicyOverride?: RemovalPolicy;
 }
 
 export class AuthStack extends Stack {
@@ -21,10 +22,11 @@ export class AuthStack extends Stack {
   constructor(scope: Construct, id: string, props: AuthStackProps) {
     super(scope, id, props);
 
-    const { applicationName, logGroupArn } = props;
+    const { applicationName, logGroupArn, removalPolicyOverride } = props;
 
     this.userPool = new UserPool(this, 'UserPool', {
       signInCaseSensitive: false,
+      removalPolicy: removalPolicyOverride,
     });
 
     this.userPoolClient = new UserPoolClient(this, 'UserPoolClient', {

--- a/cdk/lib/database/database-stack.ts
+++ b/cdk/lib/database/database-stack.ts
@@ -1,4 +1,4 @@
-import { Stack, StackProps } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import {
   AttributeType,
   BillingMode,
@@ -7,11 +7,17 @@ import {
 } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 
+export interface DatabaseStackProps extends StackProps {
+  readonly removalPolicyOverride?: RemovalPolicy;
+}
+
 export class DatabaseStack extends Stack {
   readonly resourceTable: Table;
 
-  constructor(scope: Construct, id: string, props: StackProps) {
+  constructor(scope: Construct, id: string, props: DatabaseStackProps) {
     super(scope, id, props);
+
+    const { removalPolicyOverride } = props;
 
     this.resourceTable = new Table(this, 'ResourceTable', {
       pointInTimeRecovery: true,
@@ -24,6 +30,7 @@ export class DatabaseStack extends Stack {
         type: AttributeType.STRING,
       },
       billingMode: BillingMode.PAY_PER_REQUEST,
+      removalPolicy: removalPolicyOverride,
     });
     this.resourceTable.addGlobalSecondaryIndex({
       indexName: 'resourceTypeIndex',

--- a/cdk/lib/iot-application-stack.ts
+++ b/cdk/lib/iot-application-stack.ts
@@ -1,26 +1,33 @@
-import { CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
+import { CfnOutput, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { AuthStack } from './auth/auth-stack';
 import { CoreStack } from './core/core-stack';
 import { DatabaseStack } from './database/database-stack';
 import { LoggingStack } from './logging/logging-stack';
 
+export interface LoggingStackProps extends StackProps {
+  removalPolicyOverride?: RemovalPolicy;
+}
+
 export class IotApplicationStack extends Stack {
-  constructor(scope: Construct, id: string, props: StackProps) {
+  constructor(scope: Construct, id: string, props: LoggingStackProps) {
     super(scope, id, props);
 
     const {
       logGroup: { logGroupArn },
-    } = new LoggingStack(this, 'Logging', { applicationName: id, ...props });
+    } = new LoggingStack(this, 'Logging', {
+      ...props,
+      applicationName: id,
+    });
 
     const {
       userPool: { userPoolId },
       userPoolClient: { userPoolClientId },
       identityPool: { ref: identityPoolId },
     } = new AuthStack(this, 'Auth', {
+      ...props,
       applicationName: id,
       logGroupArn,
-      ...props,
     });
 
     const {
@@ -32,6 +39,7 @@ export class IotApplicationStack extends Stack {
         service: { attrServiceUrl: coreServiceUrl },
       },
     } = new CoreStack(this, 'Core', {
+      ...props,
       coreServiceProps: {
         applicationName: id,
         databaseTableArn: tableArn,
@@ -40,12 +48,16 @@ export class IotApplicationStack extends Stack {
         userPoolClientId: userPoolClientId,
         userPoolId: userPoolId,
       },
-      ...props,
     });
 
-    new CfnOutput(this, 'App URL', {
+    new CfnOutput(this, 'AppURL', {
       description: 'Endpoint to access the App',
       value: `https://${coreServiceUrl}`,
+    });
+
+    new CfnOutput(this, 'UserPoolId', {
+      description: 'UserPool ID of the App',
+      value: userPoolId,
     });
   }
 }

--- a/cdk/lib/logging/logging-stack.ts
+++ b/cdk/lib/logging/logging-stack.ts
@@ -1,9 +1,10 @@
-import { Stack, StackProps } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 
 export interface LoggingStackProps extends StackProps {
   readonly applicationName: string;
+  readonly removalPolicyOverride?: RemovalPolicy;
 }
 
 export class LoggingStack extends Stack {
@@ -12,10 +13,11 @@ export class LoggingStack extends Stack {
   constructor(scope: Construct, id: string, props: LoggingStackProps) {
     super(scope, id, props);
 
-    const { applicationName } = props;
+    const { applicationName, removalPolicyOverride } = props;
 
     this.logGroup = new LogGroup(this, 'ApplicationLogGroup', {
       logGroupName: applicationName,
+      removalPolicy: removalPolicyOverride,
     });
   }
 }


### PR DESCRIPTION
# Description

Currently, all PR are deployed to the same `IotAppPr`  stack for `deploy-pr` workflow. The pitfalls with this approach are:
1. PR deployed application might overwritten by another PR since both all PRs are updating the same stack
2. New exported resources, introduced by a PR, cannot be deleted; that can block other PRs' deployments ([example](https://github.com/awslabs/iot-application/actions/runs/7012123772/job/19076032626#step:7:179))

This PR mitigates the issue by isolating each PR to deploy to a separate stack. By doing this:
1. reviewers are able to use the deployed application for PR changes verification
2. PR deployments do not block one another

To prevent resource buildup, added a cleanup workflow to cleanup the PR CFN stack/resources.

# How Has This Been Tested?

1. GH auto workflows and verified stack deletion after closing the PR ([run](https://github.com/awslabs/iot-application/actions/runs/7057257310/job/19210604542))
2. verified default CFN templates synthesis respect the default deletion policy (by `yarn workspace cdk cdk synthesize`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
