### PR TITLE
feat: register loggers under app-kit

### DIFF
--- a/apps/client/config-overrides.js
+++ b/apps/client/config-overrides.js
@@ -4,8 +4,10 @@ const {
   addWebpackModuleRule,
   addWebpackAlias,
   overrideDevServer,
+  addWebpackPlugin,
 } = require('customize-cra');
 const path = require('path');
+const { ModuleFederationPlugin } = require('webpack').container;
 
 module.exports = {
   devServer: overrideDevServer(
@@ -16,6 +18,17 @@ module.exports = {
     },
   ),
   webpack: override(
+    addWebpackPlugin(
+      new ModuleFederationPlugin({
+        shared: {
+          // maintains a single version of AppKit Core to work with AppKit Plugins
+          '@iot-app-kit/core': {
+            singleton: true,
+            eager: true,
+          },
+        },
+      }),
+    ),
     addWebpackAlias({
       '~': path.resolve(__dirname, 'src'),
     }),

--- a/apps/client/src/index.tsx
+++ b/apps/client/src/index.tsx
@@ -16,6 +16,8 @@ import { extractedMetaTags } from './helpers/meta-tags';
 import { registerServiceWorker } from './register-service-worker';
 import { authService } from './auth/auth-service';
 import { initializeAuthDependents } from './initialize-auth-dependents';
+import { registerLogger } from './register-loggers';
+import { registerMetricsRecorder } from './register-metrics-recorder';
 
 import '@aws-amplify/ui-react/styles.css';
 import '@cloudscape-design/global-styles/index.css';
@@ -64,5 +66,7 @@ if (rootEl != null) {
 }
 
 registerServiceWorker();
+registerLogger();
+registerMetricsRecorder();
 void authService.onSignedIn(() => initializeAuthDependents(applicationName));
 metricHandler.reportWebVitals();

--- a/apps/client/src/register-loggers.ts
+++ b/apps/client/src/register-loggers.ts
@@ -1,0 +1,8 @@
+import { registerPlugin } from '@iot-app-kit/core';
+import { cloudWatchLogger } from './logging/cloud-watch-logger';
+
+export function registerLogger() {
+  registerPlugin('logger', {
+    provider: () => cloudWatchLogger,
+  });
+}

--- a/apps/client/src/register-metrics-recorder.ts
+++ b/apps/client/src/register-metrics-recorder.ts
@@ -1,0 +1,8 @@
+import { registerPlugin } from '@iot-app-kit/core';
+import { cloudWatchMetricsRecorder } from './metrics/cloud-watch-metrics-recorder';
+
+export function registerMetricsRecorder() {
+  registerPlugin('metricsRecorder', {
+    provider: () => cloudWatchMetricsRecorder,
+  });
+}


### PR DESCRIPTION
# Description

This PR registers the plugins to monitor AppKit(logger and metric-recorder).
This PR also added a Webpack config to make the AppKit Core module a singleton. It is necessary so Webpack does not create multiple instance of the module. Otherwise, AppKit components and client could be referencing different instances of the module, making the plugin registration impossible.

# How Has This Been Tested?

- Deployed and manually tested emission of metrics
<img width="1468" alt="Screenshot 2023-12-07 at 2 38 36 AM" src="https://github.com/awslabs/iot-application/assets/50635800/82a803a1-8137-40dd-a829-85ab42f7e947">
- Verified no increase in size of the `main.xxx.js` file (remains as 7.0 MB)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
