### PR TITLE
feat: update migration UX based on feedback

### DIFF
--- a/apps/client/src/services/generated/models/MigrationStatus.ts
+++ b/apps/client/src/services/generated/models/MigrationStatus.ts
@@ -6,6 +6,7 @@ export enum Status {
   NOT_STARTED = 'not-started',
   IN_PROGRESS = 'in-progress',
   COMPLETE = 'complete',
+  COMPLETE_NONE_CREATED = 'complete-none-created',
   ERROR = 'error'
 }
   

--- a/apps/client/src/structures/notifications/info-notification.spec.ts
+++ b/apps/client/src/structures/notifications/info-notification.spec.ts
@@ -1,0 +1,12 @@
+import { Notification } from './notification';
+import { InfoNotification } from './info-notification';
+
+describe('InfoNotification', () => {
+  it('should create an info notification', () => {
+    const notification = new InfoNotification('test');
+
+    expect(notification).toBeInstanceOf(Notification);
+    expect(notification.type).toBe('info');
+    expect(notification.content).toBe('test');
+  });
+});

--- a/apps/client/src/structures/notifications/info-notification.ts
+++ b/apps/client/src/structures/notifications/info-notification.ts
@@ -1,0 +1,7 @@
+import { Notification } from './notification';
+
+export class InfoNotification extends Notification {
+  constructor(content: string) {
+    super('info', content);
+  }
+}

--- a/apps/core/src/migration/entities/migration-status.entity.ts
+++ b/apps/core/src/migration/entities/migration-status.entity.ts
@@ -4,6 +4,7 @@ export enum Status {
   NOT_STARTED = 'not-started',
   IN_PROGRESS = 'in-progress',
   COMPLETE = 'complete',
+  COMPLETE_NONE_CREATED = 'complete-none-created',
   ERROR = 'error',
 }
 

--- a/apps/core/src/migration/migration.e2e.spec.ts
+++ b/apps/core/src/migration/migration.e2e.spec.ts
@@ -203,7 +203,13 @@ describe('MigrationModule', () => {
       expect(response.statusCode).toBe(202);
 
       const status = await waitForStatus();
-      expect(status).toEqual({ status: Status.COMPLETE });
+
+      const expectedMessage =
+        'Migration complete! We successfully migrated 1 dashboard from SiteWise Monitor. You can now view this dashboard under the dashboard collection table.';
+      expect(status).toEqual({
+        status: Status.COMPLETE,
+        message: expectedMessage,
+      });
     });
 
     test('handles dashboardName when Monitor dashboard name is at the max length', async () => {
@@ -244,7 +250,13 @@ describe('MigrationModule', () => {
       expect(response.statusCode).toBe(202);
 
       const status = await waitForStatus();
-      expect(status).toEqual({ status: Status.COMPLETE });
+
+      const expectedMessage =
+        'Migration complete! We successfully migrated 1 dashboard from SiteWise Monitor. You can now view this dashboard under the dashboard collection table.';
+      expect(status).toEqual({
+        status: Status.COMPLETE,
+        message: expectedMessage,
+      });
     });
 
     test('sets status to complete when no SiteWise Monitor dashboards exist', async () => {
@@ -269,7 +281,13 @@ describe('MigrationModule', () => {
       expect(response.statusCode).toBe(202);
 
       const status = await waitForStatus();
-      expect(status).toEqual({ status: Status.COMPLETE });
+
+      const expectedMessage =
+        'There were no SiteWise Monitor dashboards available to migrate.';
+      expect(status).toEqual({
+        status: Status.COMPLETE_NONE_CREATED,
+        message: expectedMessage,
+      });
     });
 
     test('dedupe - does not create dashboards that have already been migrated', async () => {
@@ -395,7 +413,12 @@ describe('MigrationModule', () => {
         sitewiseMonitorId: testDashboard.dashboardId,
       });
 
-      expect(status).toEqual({ status: Status.COMPLETE });
+      const expectedMessage =
+        'Migration complete! We successfully migrated 4 dashboards from SiteWise Monitor. You can now view them under the dashboard collection table.';
+      expect(status).toEqual({
+        status: Status.COMPLETE,
+        message: expectedMessage,
+      });
     });
 
     test('returns 401 when request is unauthenticated', async () => {


### PR DESCRIPTION
# Description

* Updating UX based on feedback
* In success message, returning the number of dashboards created
* Adding an info notification when there are no dashboards to migrate
* Adding a modal to start the migration and scrolling to top of page at start of migration to ensure customers see the in-progress notification

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual testing, updated tests, see attached videos

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

Modal:

https://github.com/awslabs/iot-application/assets/66272633/0fc31f78-00da-4673-a9a4-81ece7963611


Success:


https://github.com/awslabs/iot-application/assets/66272633/f6e72e9d-658e-4bc4-a7b2-01e9e1ae335d



No dashboards migrated:



https://github.com/awslabs/iot-application/assets/66272633/c8f56d82-9637-4edf-a55e-a22600f9f71e


