### PR TITLE
fix: hidden decorative images from the dashboard screen

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/components/getting-started.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/components/getting-started.tsx
@@ -95,7 +95,7 @@ const GettingStarted = () => {
             <Box textAlign="center">
               <div className={col.className}>
                 {/* empty value for alt attribute to keep decorative images from screen reader */}
-                <img src={col.icon} alt="" />
+                <img src={col.icon} alt="" aria-hidden="true" />
               </div>
             </Box>
             <ValueWithLabel label={col.columnTitle}>


### PR DESCRIPTION
# Description
This PR is for ticket #1839 and to hidden Images that are decorative and do not convey any meaningful information to users from assistive technologies
1.  aria-hidden is set to true for Getting started icons

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
