### PR TITLE
fix: Docker build to install packages with frozen lockfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,8 @@
 **/.nestjs_repl_history
 **/Dockerfile
 **/.dockerignore
-**/cdk
+cdk/**
+!cdk/package.json
 
 # Editor directories and files
 **/.vscode/*


### PR DESCRIPTION
# Description

This PR allows the Docker build to install packages with frozen lockfile (`yarn.lock`). With this, each deployment is guaranteed to build with verified NPM dependencies.

Notes:
- the fix was to include package.json file from each workspace (Previously, `yarn install --frozen-lockfile` fails due to missing package.json files from some workspaces)
- explicitly listed the package.json files due to the lack of Docker build support to `COPY` with wildcard patterns
- Deleted build stage `core-modules-installer` to reduce machine resource utilizations. On my 2019 MacBook Pro, the virtual machine uses 1 fewer GB (compares to the configured MAX of 12 GB previously).

# How Has This Been Tested?

Built, deployed, tested by the deployment GH workflow

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
