### PR TITLE
chore: dashboard management e2e test resource buildup resilience

### DIFF
--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -699,10 +699,15 @@ export function DashboardsIndexPage() {
             },
             {
               id: 'lastUpdateDate',
-              header: intl.formatMessage({
-                defaultMessage: 'Date modified',
-                description: 'dashboards table last update date column header',
-              }),
+              header: (
+                <div data-testid="last-update-date-column-header">
+                  {intl.formatMessage({
+                    defaultMessage: 'Date modified',
+                    description:
+                      'dashboards table last update date column header',
+                  })}
+                </div>
+              ),
               cell: (dashboard) =>
                 intl.formatDate(dashboard.lastUpdateDate, DateFormatOptions),
               sortingField: 'lastUpdateDate',

--- a/tests/dashboards/dashboard-management.spec.ts
+++ b/tests/dashboards/dashboard-management.spec.ts
@@ -57,6 +57,13 @@ test('as a user, I can create, update, and delete my dashboard', async ({
 
   await dashboardsPage.goto();
 
+  // Sort the dashboards by last update date in descending to hoist the new dashboard
+  const lastUpdateDateSort = page
+    .getByTestId('last-update-date-column-header')
+    .first(); // Duplicates created by cloudscape
+  await lastUpdateDateSort.click(); // set to ascending order
+  await lastUpdateDateSort.click(); // set to descending order
+
   await expect(page.getByText('My Dashboard', { exact: true })).toBeVisible();
   await expect(page.getByText(dashboardDescription)).toBeVisible();
   await expect(dashboardsPage.deleteButton).toBeDisabled();


### PR DESCRIPTION
# Description

Currently, e2e test can fail if there is dashboards buildup (e.g. dashboards failed to be deleted by previous e2e test run/users manual creation of dashboards).

This PR added a sort to the dashboards table by last update date in descending to hoist the new dashboard to mitigate the buildup. However,  dashboards buildup could still happen.

# How Has This Been Tested?

successful `Playwright Test` GH workflows

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
