### PR TITLE
fix: GH WF deployment-cleanup-pr job dependency

### DIFF
--- a/.github/workflows/deployment-cleanup-pr.yml
+++ b/.github/workflows/deployment-cleanup-pr.yml
@@ -21,6 +21,7 @@ jobs:
           echo "stack_name=IotApp-PR-${{ github.head_ref }}" >> $GITHUB_OUTPUT
 
   cleanup-deploy-pr:
+    needs: [set-variables]
     timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Description

Previous commit created a bug where the `stackName` is not set correctly
[Example of run failure](https://github.com/awslabs/iot-application/actions/runs/7212206503/job/19649400037#step:7:17)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
