### PR TITLE
fix: core clean scripts to cleanup local dynamodb installation

### DIFF
--- a/apps/core/dynamodb-local-dir.js
+++ b/apps/core/dynamodb-local-dir.js
@@ -1,0 +1,14 @@
+/*
+ * This script prints the installation directory of dynamodb-local to `stdout`.
+ * It allows us to use the output in command substitution. For example, the
+ * command `ls $(node dynamodb-local-dir.js)` lists contents under the
+ * installation directory of dynamodb-local.
+ */
+
+'use strict';
+
+const os = require('os');
+const path = require('path');
+
+// reference to https://github.com/rynop/dynamodb-local/blob/1cca305c077bd600ad972569e42647d17782e921/index.js#L17
+console.log(path.join(os.tmpdir(), 'dynamodb-local'));

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "build": "nest build core",
-    "clean": "rimraf .turbo && rimraf dist && rimraf *.tsbuildinfo",
-    "clean:full": "rimraf .turbo && rimraf node_modules && rimraf dist && rimraf *.tsbuildinfo",
+    "clean": "rimraf .turbo && rimraf dist && rimraf *.tsbuildinfo && rimraf $(node dynamodb-local-dir.js)",
+    "clean:full": "rimraf .turbo && rimraf node_modules && rimraf dist && rimraf *.tsbuildinfo && rimraf $(node dynamodb-local-dir.js)",
     "dev": "yarn cognito-local & nest build --webpack --webpackPath webpack-hmr.config.js --watch",
     "start": "nest start",
     "start:debug": "nest start --debug --watch",


### PR DESCRIPTION
# Description

A few users have experienced issue starting local dynamodb with the core `dev` script previously. We were not able to identify the root cause. Fortunately, we were able to start up after cleaning up the local dynamodb installation.
This PR added local dynamodb installation cleanup to to the `clean` scripts to combat this issue aforementioned.

# How Has This Been Tested?

1. list contents the `dynamodb-local` directory to proof the existence
2. run `clean` script
3. list contents the `dynamodb-local` directory to proof the non-existence

```
chejimmy@ iot-application % ls /<tmpdir-path>/dynamodb-local
DynamoDBLocal.jar               LICENSE.txt                     THIRD-PARTY-LICENSES.txt
DynamoDBLocal_lib               README.txt                      dynamodb-local-metadata.json
chejimmy@ iot-application % yarn workspace core clean                                         
yarn workspace v1.22.19
yarn run v1.22.19
$ rimraf .turbo && rimraf dist && rimraf *.tsbuildinfo && rimraf $(node dynamodb-local-dir.js)
✨  Done in 0.77s.
✨  Done in 1.09s.
chejimmy@ iot-application % ls /<tmpdir-path>/dynamodb-local
ls: /var/folders/td/jg2x0v8136n7msnqbhyqmr100000gs/T/dynamodb-local: No such file or directory
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
