### PR TITLE
fix: save display settings in local storage

### DIFF
--- a/apps/client/src/hooks/dashboard/use-displaySettings.ts
+++ b/apps/client/src/hooks/dashboard/use-displaySettings.ts
@@ -1,0 +1,14 @@
+import { useLocalStorage } from 'react-use';
+import { DashboardDisplaySettings } from '@iot-app-kit/dashboard';
+
+const DEFAULT_DISPLAY_SETTINGS: DashboardDisplaySettings = {
+  numRows: 1000,
+  numColumns: 200,
+  cellSize: 20,
+};
+export const useDisplaySettings = (dashboardId: string) => {
+  return useLocalStorage<DashboardDisplaySettings>(
+    `dashboard-${dashboardId}-display-settings`,
+    DEFAULT_DISPLAY_SETTINGS,
+  );
+};

--- a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
@@ -15,6 +15,7 @@ import { useUpdateDashboardMutation } from '~/routes/dashboards/dashboard/hooks/
 import type { DashboardDefinition } from '~/services';
 import { useViewport } from '~/hooks/dashboard/use-viewport';
 import { useEmitNotification } from '~/hooks/notifications/use-emit-notification';
+import { useDisplaySettings } from '~/hooks/dashboard/use-displaySettings';
 import { getDashboardEditMode } from '~/store/viewMode';
 import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
 
@@ -57,6 +58,9 @@ export function DashboardPage() {
 
   const updateDashboardMutation = useUpdateDashboardMutation();
   const [viewport, saveViewport] = useViewport(params.dashboardId);
+  const [displaySettings, saveDisplaySettings] = useDisplaySettings(
+    params.dashboardId,
+  );
   if (dashboardQuery.isInitialLoading) {
     return <DashboardLoadingState />;
   }
@@ -71,12 +75,7 @@ export function DashboardPage() {
       }}
       dashboardConfiguration={{
         ...dashboardDefinition,
-        // TODO: remove display settings once dynanic sizing is released
-        displaySettings: {
-          numRows: 1000,
-          numColumns: 200,
-          cellSize: 20, // explicitly set a cell size so dashboard migration feature works as expected
-        },
+        displaySettings,
         viewport,
       }}
       initialViewMode={editMode ? 'edit' : 'preview'}
@@ -91,6 +90,7 @@ export function DashboardPage() {
             widgets: config.widgets,
           },
         });
+        saveDisplaySettings(config.displaySettings);
         saveViewport(config.viewport);
       }}
     />

--- a/tests/dashboards/dashboard-management.spec.ts
+++ b/tests/dashboards/dashboard-management.spec.ts
@@ -38,6 +38,29 @@ test('as a user, I can create, update, and delete my dashboard', async ({
   );
 
   // TODO: Need to clean up the below, we do not persist anymore
+  //check if dashboard setting persists
+  await page.getByRole('button', { name: 'Settings' }).nth(1).click();
+  await expect(page.getByLabel('Number of Rows')).toHaveValue('1000');
+  await expect(page.getByLabel('Number of Columns')).toHaveValue('200');
+  await expect(page.getByLabel('cell Size')).toHaveValue('20');
+
+  await page.getByLabel('Number of Rows').fill('100');
+  await page.getByLabel('Number of Columns').fill('100');
+  await page.getByLabel('cell Size').fill('10');
+
+  await page.getByRole('button', { name: 'Close' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await page.reload();
+  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Settings' }).nth(1).click();
+
+  await expect(page.getByLabel('Number of Rows')).toHaveValue('100');
+  await expect(page.getByLabel('Number of Columns')).toHaveValue('100');
+  await expect(page.getByLabel('cell Size')).toHaveValue('10');
+
+  await page.getByRole('button', { name: 'Close' }).click();
+
+  // check if viewport setting persists
   await page.getByRole('button', { name: 'Preview' }).click();
 
   await page.getByRole('button', { name: 'Last 5 minutes' }).click();


### PR DESCRIPTION
# Description

This PR is for ticket https://github.com/awslabs/iot-app-kit/issues/2313 and display settings are now saved in local storage. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Display settings are now stored in local storage, verified saving the dashboard settings and refreshing the screen or switching to different dashboard.
[store-display-settings.webm](https://github.com/awslabs/iot-application/assets/142866907/3b8382cb-cb68-43aa-a610-65c43d1c30ad)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
