### PR TITLE
feat: createDashboard and deleteDashboards test fixtures

### DIFF
--- a/tests/dashboard-list-page.spec.ts
+++ b/tests/dashboard-list-page.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from './helpers';
+import { DashboardsIndexPage } from './pages/dashboards-index.page';
+
+test.describe('dashboard list page', () => {
+  test('dashboard is visible', async ({
+    page,
+    createDashboard,
+    deleteDashboards,
+  }) => {
+    const dashboard = await createDashboard({
+      name: 'test dashboard name',
+      description: 'test dashboard description',
+      definition: {
+        widgets: [],
+      },
+    });
+
+    const dashboardsListPage = new DashboardsIndexPage(page);
+
+    await dashboardsListPage.goto();
+
+    await expect(page.getByText(dashboard.name)).toBeVisible();
+    await expect(page.getByText(dashboard.description)).toBeVisible();
+
+    await deleteDashboards({ ids: [dashboard.id] });
+  });
+});


### PR DESCRIPTION
# Description

This change enables the programmatic creation and deletion of dashboards (i.e., not using the UI and hitting the APIs directly) to facilitate effective Playwright testing. Without needing to create dashboards using the create dashboard page and without deleting dashboards on the dashboards list page, more tests and more robust tests may be written. Test fixtures are used to hide the details of session tokens.

The newly added test is temporary and was added to simply demonstrate usage of the fixtures.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
