### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/dependabot-hook.yml
+++ b/.github/workflows/dependabot-hook.yml
@@ -29,7 +29,7 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             if [[ "${FAILED_CHECKS[@]}" =~ "${check}" ]]; then
               echo "Failed required check: ${check}"
-              echo "::set-output name=close_pr::true"
+              echo "close_pr=true" >> "$GITHUB_OUTPUT"
               break
             fi
           done


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter