### PR TITLE
feat: add local mode for client logs/metrics

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -13,6 +13,8 @@
     <meta name="userPoolWebClientId" content="{{userPoolWebClientId}}" />
     <meta name="userPoolId" content="{{userPoolId}}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="logMode" content="{{logMode}}" />
+    <meta name="metricsMode" content="{{metricsMode}}" />
 
     <title>IoT Application</title>
   </head>

--- a/apps/client/src/helpers/meta-tags.ts
+++ b/apps/client/src/helpers/meta-tags.ts
@@ -14,6 +14,8 @@ export const extractedMetaTags = (
     region: '',
     userPoolId: '',
     userPoolWebClientId: '',
+    logMode: '',
+    metricsMode: '',
   };
 
   metaElements.forEach(

--- a/apps/client/src/index.tsx
+++ b/apps/client/src/index.tsx
@@ -36,6 +36,8 @@ const {
   region,
   userPoolId,
   userPoolWebClientId,
+  logMode,
+  metricsMode,
 } = metadata;
 
 Amplify.configure({
@@ -78,7 +80,7 @@ if (rootEl != null) {
 }
 
 registerServiceWorker();
-registerLogger();
-registerMetricsRecorder();
+registerLogger(logMode);
+registerMetricsRecorder(metricsMode);
 void authService.onSignedIn(() => initializeAuthDependents(applicationName));
 metricHandler.reportWebVitals();

--- a/apps/client/src/register-loggers.ts
+++ b/apps/client/src/register-loggers.ts
@@ -1,8 +1,24 @@
 import { registerPlugin } from '@iot-app-kit/core';
 import { cloudWatchLogger } from './logging/cloud-watch-logger';
 
-export function registerLogger() {
-  registerPlugin('logger', {
-    provider: () => cloudWatchLogger,
-  });
+const LogModes = {
+  Local: 'local',
+  Cloud: 'cloud',
+};
+
+export function registerLogger(logMode: string) {
+  if (logMode === LogModes.Local) {
+    registerPlugin('logger', {
+      provider: () => ({
+        /* eslint-disable no-console */
+        log: (...args) => console.log('logging:', ...args),
+        error: (...args) => console.error('logging:', ...args),
+        warn: (...args) => console.warn('logging:', ...args),
+      }),
+    });
+  } else {
+    registerPlugin('logger', {
+      provider: () => cloudWatchLogger,
+    });
+  }
 }

--- a/apps/client/src/register-metrics-recorder.ts
+++ b/apps/client/src/register-metrics-recorder.ts
@@ -1,8 +1,22 @@
 import { registerPlugin } from '@iot-app-kit/core';
 import { cloudWatchMetricsRecorder } from './metrics/cloud-watch-metrics-recorder';
 
-export function registerMetricsRecorder() {
-  registerPlugin('metricsRecorder', {
-    provider: () => cloudWatchMetricsRecorder,
-  });
+const MetricModes = {
+  Local: 'local',
+  Cloud: 'cloud',
+};
+
+export function registerMetricsRecorder(metricsMode: string) {
+  if (metricsMode === MetricModes.Local) {
+    registerPlugin('metricsRecorder', {
+      provider: () => ({
+        /* eslint-disable no-console */
+        record: (...args) => console.log('record metric:', ...args),
+      }),
+    });
+  } else {
+    registerPlugin('metricsRecorder', {
+      provider: () => cloudWatchMetricsRecorder,
+    });
+  }
 }

--- a/apps/client/src/types/metadata.ts
+++ b/apps/client/src/types/metadata.ts
@@ -9,4 +9,6 @@ export interface Metadata {
   region: string;
   userPoolId: string;
   userPoolWebClientId: string;
+  logMode: string;
+  metricsMode: string;
 }

--- a/apps/core/src/config/global.config.spec.ts
+++ b/apps/core/src/config/global.config.spec.ts
@@ -1,15 +1,32 @@
 import { configFactory } from './global.config';
 import { envVarRequiredMsg } from './environment';
+import { MetricModes, LogModes } from '../types/environment';
 
 describe('globalConfig', () => {
   describe('configFactory', () => {
-    test('returns environment values', () => {
+    test('returns environment values in local mode', () => {
       const applicationName = 'ApplicationName';
 
       process.env.APPLICATION_NAME = applicationName;
+      process.env.NODE_ENV = 'development';
 
       expect(configFactory()).toEqual({
         applicationName: applicationName,
+        logMode: LogModes.Local,
+        metricsMode: MetricModes.Local,
+      });
+    });
+
+    test('returns environment values in cloud mode', () => {
+      const applicationName = 'ApplicationName';
+
+      process.env.APPLICATION_NAME = applicationName;
+      process.env.NODE_ENV = 'production';
+
+      expect(configFactory()).toEqual({
+        applicationName: applicationName,
+        logMode: LogModes.Cloud,
+        metricsMode: MetricModes.Cloud,
       });
     });
 

--- a/apps/core/src/config/global.config.ts
+++ b/apps/core/src/config/global.config.ts
@@ -2,14 +2,26 @@ import { registerAs } from '@nestjs/config';
 import { isDefined } from '../types/environment';
 import invariant from 'tiny-invariant';
 import { envVarRequiredMsg } from './environment';
+import { getLogMode, getMetricsMode } from '../types/environment';
 
 export const configFactory = () => {
   const { APPLICATION_NAME: applicationName } = process.env;
 
   invariant(isDefined(applicationName), envVarRequiredMsg('APPLICATION_NAME'));
 
+  const logMode = getLogMode();
+  const metricsMode = getMetricsMode();
+
+  invariant(isDefined(logMode), 'Something went wrong getting log mode.');
+  invariant(
+    isDefined(metricsMode),
+    'Something went wrong getting metrics mode.',
+  );
+
   return {
     applicationName,
+    logMode,
+    metricsMode,
   };
 };
 

--- a/apps/core/src/mvc/mvc.controller.ts
+++ b/apps/core/src/mvc/mvc.controller.ts
@@ -31,7 +31,7 @@ export class MvcController {
       userPoolId,
     } = this.auth;
 
-    const { applicationName } = this.global;
+    const { applicationName, logMode, metricsMode } = this.global;
 
     return {
       applicationName,
@@ -44,6 +44,8 @@ export class MvcController {
       region,
       userPoolId,
       userPoolWebClientId,
+      logMode,
+      metricsMode,
     };
   }
 }

--- a/apps/core/src/types/environment.ts
+++ b/apps/core/src/types/environment.ts
@@ -13,3 +13,27 @@ export function isDefined<T>(maybe: Maybe<T>): maybe is Defined<T> {
 export function isDevEnv() {
   return process.env.NODE_ENV === 'development';
 }
+
+export const MetricModes = {
+  Local: 'local',
+  Cloud: 'cloud',
+};
+
+export const LogModes = {
+  Local: 'local',
+  Cloud: 'cloud',
+};
+
+export function getMetricsMode() {
+  if (isDevEnv()) {
+    return MetricModes.Local;
+  }
+  return MetricModes.Cloud;
+}
+
+export function getLogMode() {
+  if (isDevEnv()) {
+    return LogModes.Local;
+  }
+  return LogModes.Cloud;
+}


### PR DESCRIPTION
# Description

* Adding a local mode so the client logger and metrics recorder will function in local development
* Passing `logMode` and `metricsMode` from core config and using `console.log` for metrics and logging while in dev mode instead of the services 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested locally that `console.log` was used and in the cloud that the metrics service was used 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
