### PR TITLE
chore: added scripts and updated readme to simplify cloud deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,21 @@ Start using the application today to quickly create, manage, and view your IoT d
 
 ## Prerequisites
 
+On most Unix systems including macOS, you can install the prerequisites with a single command:
+```sh
+./install-prepreqs-unix.sh
+```
+
+Alternatively, you can install the prerequisites by following the instruction below:
+
 1. [Install Volta](https://docs.volta.sh/guide/getting-started) using the environment specific commands listed below
    * Unix based environments
       ```sh
       curl https://get.volta.sh | bash
       ```
+      After installing Volta, if applicable, you may need to refresh your bash profile using `source ~/.bashrc` to use Volta commands
    * Windows environments
       * Download and run Windows installer [here](https://docs.volta.sh/guide/getting-started)
-1. After installing Volta, if applicable, you may need to refresh your bash profile using `source ~/.bashrc` to use Volta commands
 1. [Install Node.js@18](https://docs.volta.sh/guide/#features) with Volta
    ```sh
    volta install node@18

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -10,7 +10,10 @@
     "clean": "rimraf .turbo && rimraf dist",
     "clean:full": "rimraf .turbo && rimraf node_modules && rimraf dist",
     "watch": "tsc -w",
+    "bootstrap": "cdk bootstrap",
     "cdk": "cdk",
+    "deploy": "cdk deploy --all",
+    "deploy:no-review": "cdk deploy --all --require-approval never",
     "lint": "TIMING=1 eslint \"{bin,lib}/**/*.ts\" --max-warnings 0",
     "lint:commit": "tsc --noEmit && TIMING=1 eslint $(git diff --name-only HEAD HEAD~1 | grep -E \"{bin,lib}/**/*.ts\" | xargs) --max-warnings 0",
     "lint:fix": "eslint \"{bin,lib}/**/*.ts\" --fix"

--- a/deploymentguide/README.md
+++ b/deploymentguide/README.md
@@ -11,35 +11,35 @@ This will deploy the application to your AWS account using CDK.
 
 ##### Deployment prerequisites steps:
 
-1. Complete the general [prerequisites](https://github.com/awslabs/iot-application/blob/main/README.md#prerequisites) to install Volta, Node and Yarn
-1. [Configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) AWS CLI credentials for making AWS service calls with CDK for the deployment
 1. Install docker. Docker must be running when you run the deployment commands.
    * If using an AWS environment, please follow [these instructions](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-docker.html)
    * If using a non-AWS environment, please follow the [platform specific instructions here](https://docs.docker.com/engine/install/)
-1. Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and clone repo
+1. Download and unzip the application repository from the [download link](https://github.com/awslabs/iot-application/archive/refs/heads/main.zip)
+   Alternatively, install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and clone the repository:
    ```sh
    git clone https://github.com/awslabs/iot-application.git
    ```
-1. Navigate to root directory `iot-application` and install application dependencies:
-   ```sh
-   yarn install
-   ```
+1. [Configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) AWS CLI credentials for making AWS service calls with CDK for the deployment
 
 ##### Deployment to cloud:
 
 Note: All commands should be run in the workspace root directory. We are using [yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/) to handle individual package commands.
 
-1. Add your AWS accountId and region [here](https://github.com/awslabs/iot-application/blob/main/cdk/bin/cdk.ts#L17) to setup the cdk envrionment.
-1. For the initial deployment only, bootstrap cdk in your account:
-   ```sh
-   yarn workspace cdk cdk bootstrap
-   ```
-1. Deploy the application using the deploy command:
+On most Unix systems including macOS, you can deploy the application with a single command:
+```sh
+./install-deploy-unix.sh
+```
+At the end of the deployment, the output value of `IotApp.AppURL` shows the URL of the application.
+
+Alternatively, you can deploy the application by following the instruction below:
+
+1. Complete the general [prerequisites](https://github.com/awslabs/iot-application/blob/main/README.md#prerequisites) to install Volta, Node and Yarn
+1. Deploy the application using the deploy command with a single command:
    ```sh
    yarn deploy
    ```
-1. This will install dependencies and deploy the application to the cloud using CDK and creating CloudFormation stacks that support the application.
-1. View your application resources in CloudFormation. If you go to the stack `IotApp -> Outputs` you can see the URL that the application will be available from.
+   This will install dependencies and deploy the application to the cloud using CDK and creating CloudFormation stacks that support the application.
+   At the end of the deployment, the output value of `IotApp.AppURL` shows the URL of the application.
 
 ##### Updating the cloud application:
 1. Get the latest code changes using `git fetch` and `git pull` from the root directory of the application.

--- a/install-deploy-unix.sh
+++ b/install-deploy-unix.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script installs prerequesites and deploy the application for Unix based
+# system.
+
+# Install prerequesites
+. install-prepreqs-unix.sh
+
+# Deploy the application
+echo "Deploying the application..."
+yarn deploy
+echo

--- a/install-prepreqs-unix.sh
+++ b/install-prepreqs-unix.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script installs Node.JS related prerequesites for Unix based system.
+
+# Install Volta
+echo "Installing Volta..."
+curl https://get.volta.sh | bash
+echo
+
+# Install Node.js@18 with Volta
+echo "Installing Node.js@18..."
+volta install node@18
+echo
+
+# Install Yarn with Volta
+echo "Install Yarn..."
+volta install yarn
+echo

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "npx turbo run clean && rimraf .turbo && rimraf *.tsbuildinfo",
     "clean:full": "npx turbo run clean:full && rimraf .turbo && rimraf *.tsbuildinfo && rimraf node_modules",
     "dev": "turbo run dev",
-    "deploy": "yarn install && yarn clean && yarn workspace cdk cdk deploy --all",
+    "deploy": "yarn install && yarn clean && yarn workspace cdk bootstrap && yarn workspace cdk deploy:no-review",
     "gen:types": "openapi -i ${npm_package_config_docs} -o ${npm_package_config_genpath} ${npm_package_config_genconfig} && yarn format:gen:types",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:gen:types": "prettier --write \"${npm_package_config_genpath}/**/*.ts\"",


### PR DESCRIPTION
# Description

This PR simplifies the cloud deployment process for Unix systems (including MacOS) by introducing 2 new shell scripts
1. prepre setup
1. prepre setup + application deployment

This PR also updates the README.md files accordingly.

This PR does not make the deployment a "1-click" command due to the difficulty to install Docker. In summary, the process becomes:

1. [2 min] Install docker
1. [1 min] Download and unzip the repo https://github.com/awslabs/iot-application/archive/refs/heads/main.zip
1. [1 min] Get AWS Creds
1. [~15 min] Install prereqs + Deploy to cloud with `./install-deploy-unix.sh`

# How Has This Been Tested?

Verified and deployed to cloud successfully

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
