### PR TITLE
fix: update path as part of the prepres install

### DIFF
--- a/install-prepreqs-unix.sh
+++ b/install-prepreqs-unix.sh
@@ -5,6 +5,8 @@
 # Install Volta
 echo "Installing Volta..."
 curl https://get.volta.sh | bash
+export VOLTA_HOME="$HOME/.volta"
+export PATH="$VOLTA_HOME/bin:$PATH"
 echo
 
 # Install Node.js@18 with Volta


### PR DESCRIPTION
# Description

The previous commit has a bug where the `volta` command is not available during the execution (https://github.com/awslabs/iot-application/pull/1966)
This PR fixes the problem by exporting the volta home path

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Complete [uninstall of volta](https://docs.volta.sh/advanced/uninstall) and reran the script

<img width="576" alt="Screenshot 2024-02-02 at 3 09 01 PM" src="https://github.com/awslabs/iot-application/assets/50635800/3ea10257-7075-4f63-8d8d-5dc2404f8a89">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
