### PR TITLE
feat: add core service for proxying edge login call

### DIFF
--- a/apps/core/src/app.module.ts
+++ b/apps/core/src/app.module.ts
@@ -12,6 +12,7 @@ import { authConfig } from './config/auth.config';
 import { MvcModule } from './mvc/mvc.module';
 import { jwtConfig } from './config/jwt.config';
 import { MigrationModule } from './migration/migration.module';
+import { EdgeLoginModule } from './edge-login/edge-login.module';
 import { LoggerModule } from './logging/logger.module';
 import { globalConfig } from './config/global.config';
 
@@ -23,6 +24,7 @@ import { globalConfig } from './config/global.config';
     }),
     DashboardsModule,
     MigrationModule,
+    EdgeLoginModule,
     MvcModule,
     HealthModule,
     LoggerModule.forRoot(),

--- a/apps/core/src/edge-login/README.md
+++ b/apps/core/src/edge-login/README.md
@@ -1,0 +1,5 @@
+# EdgeLogin
+
+`EdgeLoginModule` extends Core with the `/edge-login` REST API.
+
+This module is for calling the `/authenticate` endpoint of a SiteWise Edge Gateway. The endpoint does not have CORS support, so this endpoint is used to proxy the call from the client.

--- a/apps/core/src/edge-login/edge-login.controller.ts
+++ b/apps/core/src/edge-login/edge-login.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { EdgeLoginService } from './edge-login.service';
+import { Public } from '../auth/public.decorator';
+import { EdgeCredentials } from './entities/edge-credentials.entity';
+import { EdgeLoginBody } from './entities/edge-login-body.entity';
+import { isErr } from '../types';
+
+@ApiTags('edge-login')
+@Controller('api/edge-login')
+export class EdgeLoginController {
+  constructor(private readonly edgeLoginService: EdgeLoginService) {}
+
+  @Public()
+  @Post()
+  public async edgeLogin(
+    @Body() edgeLoginBody: EdgeLoginBody,
+  ): Promise<EdgeCredentials> {
+    const result = await this.edgeLoginService.login(edgeLoginBody);
+
+    if (isErr(result)) {
+      throw result.err;
+    }
+
+    return result.ok;
+  }
+}

--- a/apps/core/src/edge-login/edge-login.e2e.spec.ts
+++ b/apps/core/src/edge-login/edge-login.e2e.spec.ts
@@ -1,0 +1,122 @@
+import { ValidationPipe } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../app.module';
+import { configureTestProcessEnv } from '../testing/aws-configuration';
+import { EdgeLoginService } from './edge-login.service';
+import { HttpModule, HttpService } from '@nestjs/axios';
+import { EdgeCredentials } from './entities/edge-credentials.entity';
+
+describe('EdgeLoginModule', () => {
+  let app: NestFastifyApplication;
+  let edgeLoginService: EdgeLoginService;
+  let edgeLoginSpy: jest.SpyInstance;
+
+  let httpService: HttpService;
+  let httpServiceSpy: jest.SpyInstance;
+
+  const testData: EdgeCredentials = {
+    accessKeyId: '',
+    secretAccessKey: '',
+    sessionToken: '',
+    sessionExpiryTime: '',
+  };
+
+  const edgeCredentialResponse = {
+    data: testData,
+    headers: {},
+    config: { url: 'http://localhost:3000/mockUrl' },
+    status: 200,
+    statusText: 'OK',
+  };
+
+  beforeEach(async () => {
+    configureTestProcessEnv(process.env);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, HttpModule],
+      providers: [EdgeLoginService],
+    }).compile();
+
+    edgeLoginService = moduleRef.get<EdgeLoginService>(EdgeLoginService);
+    edgeLoginSpy = jest.spyOn(edgeLoginService, 'login');
+
+    httpService = moduleRef.get<HttpService>(HttpService);
+    httpServiceSpy = jest
+      .spyOn(httpService.axiosRef, 'post')
+      .mockImplementationOnce(() => Promise.resolve(edgeCredentialResponse));
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
+    await app.init();
+
+    const instance = app.getHttpAdapter().getInstance() as unknown as {
+      ready(): Promise<void>;
+    };
+
+    await instance.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('POST /api/migration HTTP/1.1', () => {
+    test('correctly proxies the edge credential request', async () => {
+      const requestBody = {
+        edgeEndpoint: '1.2.3.4.5',
+        username: 'testUser',
+        password: 'testPassword',
+        authMechanism: 'linux',
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/edge-login',
+        payload: requestBody,
+      });
+
+      expect(edgeLoginSpy).toHaveBeenCalled();
+      expect(httpServiceSpy).toHaveBeenCalled();
+      expect(response.statusCode).toBe(201);
+    });
+
+    test('returns an error if the axios call fails with valid input', async () => {
+      const errorResponse = {
+        data: {},
+        headers: {},
+        config: { url: 'http://localhost:3000/mockUrl' },
+        status: 500,
+        statusText: 'OK',
+      };
+      httpServiceSpy.mockReset();
+      httpServiceSpy = jest
+        .spyOn(httpService.axiosRef, 'post')
+        .mockRejectedValueOnce(errorResponse);
+
+      const requestBody = {
+        edgeEndpoint: '1.2.3.4.5',
+        username: 'testUser',
+        password: 'testPassword',
+        authMechanism: 'linux',
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/edge-login',
+        payload: requestBody,
+      });
+
+      expect(edgeLoginSpy).toHaveBeenCalled();
+      expect(httpServiceSpy).toHaveBeenCalled();
+      expect(response.statusCode).toBe(500);
+    });
+  });
+});

--- a/apps/core/src/edge-login/edge-login.module.ts
+++ b/apps/core/src/edge-login/edge-login.module.ts
@@ -1,0 +1,15 @@
+import { Module, ModuleMetadata } from '@nestjs/common';
+
+import { EdgeLoginController } from './edge-login.controller';
+import { EdgeLoginService } from './edge-login.service';
+import { HttpModule } from '@nestjs/axios';
+
+export const edgeLoginModuleMetadata: ModuleMetadata = {
+  imports: [HttpModule],
+  controllers: [EdgeLoginController],
+  providers: [EdgeLoginService],
+};
+
+/** Core Dashboards Module */
+@Module(edgeLoginModuleMetadata)
+export class EdgeLoginModule {}

--- a/apps/core/src/edge-login/edge-login.service.ts
+++ b/apps/core/src/edge-login/edge-login.service.ts
@@ -1,0 +1,39 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { EdgeCredentials } from './entities/edge-credentials.entity';
+import { EdgeLoginBody } from './entities/edge-login-body.entity';
+import { Result, err, ok } from '../types';
+
+@Injectable()
+export class EdgeLoginService {
+  constructor(private readonly httpService: HttpService) {}
+
+  public async login(
+    body: EdgeLoginBody,
+  ): Promise<Result<Error, EdgeCredentials>> {
+    try {
+      const result = await this.httpService.axiosRef.post<EdgeCredentials>(
+        `${body.edgeEndpoint}/authenticate`,
+        {
+          username: body.username,
+          password: body.password,
+          authMechanism: body.authMechanism,
+        },
+      );
+
+      const { accessKeyId, secretAccessKey, sessionToken, sessionExpiryTime } =
+        result.data;
+
+      return ok({
+        accessKeyId,
+        secretAccessKey,
+        sessionToken,
+        sessionExpiryTime,
+      });
+    } catch (error) {
+      return error instanceof Error
+        ? err(error)
+        : err(new Error('Error getting edge credentials'));
+    }
+  }
+}

--- a/apps/core/src/edge-login/entities/edge-credentials.entity.ts
+++ b/apps/core/src/edge-login/entities/edge-credentials.entity.ts
@@ -1,0 +1,6 @@
+export interface EdgeCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  sessionExpiryTime?: string;
+}

--- a/apps/core/src/edge-login/entities/edge-login-body.entity.ts
+++ b/apps/core/src/edge-login/entities/edge-login-body.entity.ts
@@ -1,0 +1,27 @@
+import { IsString } from 'class-validator';
+
+export class EdgeLoginBody {
+  /**
+   * @example "192.168.0.1"
+   */
+  @IsString()
+  public readonly edgeEndpoint: string;
+
+  /**
+   * @example "user"
+   */
+  @IsString()
+  public readonly username: string;
+
+  /**
+   * @example "password"
+   */
+  @IsString()
+  public readonly password: string;
+
+  /**
+   * @example "linux"
+   */
+  @IsString()
+  public readonly authMechanism: string;
+}


### PR DESCRIPTION
# Description

* Adding a Core api for proxying the call for edge login. The reason for this is SiteWise Edge Gateways do not have CORS support and so the call to the edge gateway to get the edge credentials must be proxied. 
* This API will be called by the client when in edge mode during the edge login process. It will return the AWS credentials for making the Sitewise edge API calls.
* There is some followup work to include a certificate for this call similar to [here](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/manage-gateways-ggv2.html#manage-gateway-certificate). Because Edge Gateways self-sign their certificates, we need to provide a way for customers to download and provide this certificate so we can add it to the trusted certs. 

# Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested the login flow with in-progress client code and the call was successful and avoided the previous CORS issue.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
