### PR TITLE
feat: add generated client for calling edge login

### DIFF
--- a/apps/client/src/services/generated/index.ts
+++ b/apps/client/src/services/generated/index.ts
@@ -24,4 +24,5 @@ export { $UpdateDashboardDto } from './schemas/$UpdateDashboardDto';
 
 export { DashboardsService } from './services/DashboardsService';
 export { MigrationService } from './services/MigrationService';
+export { EdgeLoginService } from './services/EdgeLoginService';
 export { DefaultService } from './services/DefaultService';

--- a/apps/client/src/services/generated/models/EdgeCredentials.ts
+++ b/apps/client/src/services/generated/models/EdgeCredentials.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type EdgeCredentials = {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+    sessionExpiryTime?: string;
+}

--- a/apps/client/src/services/generated/models/EdgeLoginBody.ts
+++ b/apps/client/src/services/generated/models/EdgeLoginBody.ts
@@ -1,0 +1,6 @@
+export type EdgeLoginBody = {
+    edgeEndpoint: string;
+    username: string;
+    password: string;
+    authMechanism: string;
+}

--- a/apps/client/src/services/generated/services/EdgeLoginService.ts
+++ b/apps/client/src/services/generated/services/EdgeLoginService.ts
@@ -1,0 +1,22 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+import { EdgeCredentials } from '../models/EdgeCredentials';
+import { EdgeLoginBody } from '../models/EdgeLoginBody';
+
+export class EdgeLoginService {
+  /**
+   * @returns void
+   * @throws ApiError
+   */
+  public static edgeLogin(requestBody: EdgeLoginBody): CancelablePromise<EdgeCredentials> {
+    return __request(OpenAPI, {
+      method: 'POST',
+      url: '/edge-login',
+      body: requestBody,
+    });
+  }
+}

--- a/apps/client/src/services/index.ts
+++ b/apps/client/src/services/index.ts
@@ -2,7 +2,12 @@ export * from './generated';
 export { intl } from './intl';
 
 import { v4 as uuid } from 'uuid';
-import { OpenAPI, DashboardsService, MigrationService } from './generated';
+import {
+  OpenAPI,
+  DashboardsService,
+  MigrationService,
+  EdgeLoginService,
+} from './generated';
 
 import { authService } from '~/auth/auth-service';
 
@@ -55,3 +60,8 @@ export const dashboardMigration: DashboardMigration = () =>
   MigrationService.migrationControllerMigration();
 export const dashboardMigrationStatus: DashboardMigrationStatus = () =>
   MigrationService.migrationControllerGetMigrationStatus();
+
+// EdgeLogin API
+export type EdgeLogin = typeof EdgeLoginService.edgeLogin;
+
+export const edgeLogin: EdgeLogin = (body) => EdgeLoginService.edgeLogin(body);


### PR DESCRIPTION
# Description
* Add the generated client service for calling the edge login endpoint from https://github.com/awslabs/iot-application/pull/2000

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Able to use service to call edge login endpoint and see a successful response

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
