### PR TITLE
feat: use react hooks for edge login form

### DIFF
--- a/apps/client/src/routes/edge-login/components/edge-endpoint-field.tsx
+++ b/apps/client/src/routes/edge-login/components/edge-endpoint-field.tsx
@@ -1,0 +1,41 @@
+import FormField from '@cloudscape-design/components/form-field';
+import Input from '@cloudscape-design/components/input';
+import { Controller } from 'react-hook-form';
+
+import type { Control } from 'react-hook-form';
+import type { EdgeLoginFormValues } from '../hooks/use-edge-login-form';
+import { isJust } from '~/helpers/predicates/is-just';
+
+interface EdgeEndpointFieldProps {
+  control: Control<EdgeLoginFormValues>;
+}
+
+export function EdgeEndpointField(props: EdgeEndpointFieldProps) {
+  return (
+    <Controller
+      control={props.control}
+      name="edgeEndpoint"
+      rules={{
+        required: 'Hostname is required.',
+        maxLength: {
+          value: 256, // Hostname can be max 253 ASCII characters
+          message: 'Hostname must be {maxLength} characters or less.',
+        },
+      }}
+      render={({ field, fieldState }) => (
+        <FormField
+          label="Hostname or IP address"
+          description="The hostname or IP adddress of the gateway device."
+          errorText={isJust(fieldState.error) ? fieldState.error.message : ''}
+        >
+          <Input
+            ariaLabel="Enter hostname or IP address"
+            onChange={(event) => field.onChange(event.detail.value)}
+            value={field.value}
+            placeholder="Enter hostname or IP address"
+          />
+        </FormField>
+      )}
+    />
+  );
+}

--- a/apps/client/src/routes/edge-login/components/edge-mechanism-field.tsx
+++ b/apps/client/src/routes/edge-login/components/edge-mechanism-field.tsx
@@ -1,0 +1,47 @@
+import FormField from '@cloudscape-design/components/form-field';
+import { Controller } from 'react-hook-form';
+
+import type { Control } from 'react-hook-form';
+import type { EdgeLoginFormValues } from '../hooks/use-edge-login-form';
+import Select from '@cloudscape-design/components/select';
+
+interface EdgeMechanismFieldProps {
+  control: Control<EdgeLoginFormValues>;
+}
+
+const authOptions = [
+  { label: 'Linux', value: 'linux' },
+  { label: 'LDAP', value: 'ldap' },
+];
+
+const valueToLabel = {
+  linux: 'Linux',
+  ldap: 'LDAP',
+};
+
+export function EdgeMechanismField(props: EdgeMechanismFieldProps) {
+  return (
+    <Controller
+      control={props.control}
+      name="authMechanism"
+      render={({ field }) => (
+        <FormField
+          label="Authentication type"
+          description="You can authenticate to this gateway with your Operating System Authentication or Lightweight Directory Access Protocol (LDAP) credentials."
+        >
+          <Select
+            ariaLabel="Select an authentication type"
+            onChange={(event) =>
+              field.onChange(event.detail.selectedOption.value)
+            }
+            selectedOption={{
+              label: valueToLabel[field.value],
+              value: field.value,
+            }}
+            options={authOptions}
+          />
+        </FormField>
+      )}
+    />
+  );
+}

--- a/apps/client/src/routes/edge-login/components/edge-password-field.tsx
+++ b/apps/client/src/routes/edge-login/components/edge-password-field.tsx
@@ -1,0 +1,42 @@
+import FormField from '@cloudscape-design/components/form-field';
+import Input from '@cloudscape-design/components/input';
+import { Controller } from 'react-hook-form';
+
+import type { Control } from 'react-hook-form';
+import type { EdgeLoginFormValues } from '../hooks/use-edge-login-form';
+import { isJust } from '~/helpers/predicates/is-just';
+
+interface EdgePasswordFieldProps {
+  control: Control<EdgeLoginFormValues>;
+}
+
+export function EdgePasswordField(props: EdgePasswordFieldProps) {
+  return (
+    <Controller
+      control={props.control}
+      name="password"
+      rules={{
+        required: 'Password is required.',
+        maxLength: {
+          value: 256,
+          message: 'Password must be {maxLength} characters or less.',
+        },
+      }}
+      render={({ field, fieldState }) => (
+        <FormField
+          label="Password"
+          description="The password of your operating system or LDAP user."
+          errorText={isJust(fieldState.error) ? fieldState.error.message : ''}
+        >
+          <Input
+            ariaLabel="Enter password"
+            onChange={(event) => field.onChange(event.detail.value)}
+            value={field.value}
+            type="password"
+            placeholder="Enter password"
+          />
+        </FormField>
+      )}
+    />
+  );
+}

--- a/apps/client/src/routes/edge-login/components/edge-username-field.tsx
+++ b/apps/client/src/routes/edge-login/components/edge-username-field.tsx
@@ -1,0 +1,41 @@
+import FormField from '@cloudscape-design/components/form-field';
+import Input from '@cloudscape-design/components/input';
+import { Controller } from 'react-hook-form';
+
+import type { Control } from 'react-hook-form';
+import type { EdgeLoginFormValues } from '../hooks/use-edge-login-form';
+import { isJust } from '~/helpers/predicates/is-just';
+
+interface EdgeUsernameFieldProps {
+  control: Control<EdgeLoginFormValues>;
+}
+
+export function EdgeUsernameField(props: EdgeUsernameFieldProps) {
+  return (
+    <Controller
+      control={props.control}
+      name="username"
+      rules={{
+        required: 'Username is required.',
+        maxLength: {
+          value: 256,
+          message: 'Username must be {maxLength} characters or less.',
+        },
+      }}
+      render={({ field, fieldState }) => (
+        <FormField
+          label="Username"
+          description="The user name of your operating system or LDAP."
+          errorText={isJust(fieldState.error) ? fieldState.error.message : ''}
+        >
+          <Input
+            ariaLabel="Enter username"
+            onChange={(event) => field.onChange(event.detail.value)}
+            value={field.value}
+            placeholder="Enter username"
+          />
+        </FormField>
+      )}
+    />
+  );
+}

--- a/apps/client/src/routes/edge-login/edge-login-page.spec.tsx
+++ b/apps/client/src/routes/edge-login/edge-login-page.spec.tsx
@@ -15,14 +15,12 @@ const hostName = '1.2.3.4.5';
 const username = 'username';
 const password = 'password';
 
-vi.mock('./hooks/use-edge-login-query', () => ({
-  useEdgeLoginQuery: vi.fn().mockReturnValue({
-    refetch: vi.fn().mockReturnValue({
-      data: {
-        accessKey: '',
-        secretKeyId: '',
-      },
-    }),
+vi.mock('~/services', () => ({
+  edgeLogin: vi.fn().mockReturnValue({
+    data: {
+      accessKey: '',
+      secretKeyId: '',
+    },
   }),
 }));
 

--- a/apps/client/src/routes/edge-login/edge-login-page.tsx
+++ b/apps/client/src/routes/edge-login/edge-login-page.tsx
@@ -4,60 +4,60 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
-import FormField from '@cloudscape-design/components/form-field';
-import Input from '@cloudscape-design/components/input';
-import Select from '@cloudscape-design/components/select';
 import Box from '@cloudscape-design/components/box';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 import { colorBackgroundHomeHeader } from '@cloudscape-design/design-tokens';
+import { DevTool } from '@hookform/devtools';
 import { authService } from '../../auth/auth-service';
 import { PropsWithChildren } from 'react';
-import { useEdgeLoginQuery } from './hooks/use-edge-login-query';
+import { useEdgeLoginForm } from './hooks/use-edge-login-form';
+import { EdgeEndpointField } from './components/edge-endpoint-field';
+import { EdgeUsernameField } from './components/edge-username-field';
+import { EdgeMechanismField } from './components/edge-mechanism-field';
+import { EdgePasswordField } from './components/edge-password-field';
+import { edgeLogin } from '~/services';
 
-// Define an empty type to use PropsWithChildren<EdgeLoginProps>
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface EdgeLoginProps {}
-
-export function EdgeLoginPage({ children }: PropsWithChildren<EdgeLoginProps>) {
+export function EdgeLoginPage({ children }: PropsWithChildren) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [ipAddress, setIpAddress] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [authMechanism, setAuthMechanism] = useState({
-    label: 'Linux',
-    value: 'linux',
-  });
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
-  const { refetch } = useEdgeLoginQuery({
-    edgeEndpoint: ipAddress,
-    username,
-    password,
-    authMechanism: authMechanism.value,
-  });
+  const { control, handleSubmit } = useEdgeLoginForm();
 
-  const getCredentials = async () => {
-    const { data } = await refetch();
-    if (data) {
-      authService.setAwsCredentials(data);
-      setIsLoggedIn(true);
-    } else {
-      setError('Error logging in');
-    }
-  };
+  const isProdEnv: boolean = process.env.NODE_ENV === 'production';
+
   if (isLoggedIn) {
     return children;
   } else {
     return (
       <ColumnLayout columns={3}>
-        <div></div>
+        <div />
         <Box margin="xxxl">
-          <form onSubmit={(e) => e.preventDefault()}>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+
+              void handleSubmit(async (formData) => {
+                try {
+                  setIsLoading(true);
+                  const data = await edgeLogin(formData);
+                  authService.setAwsCredentials(data);
+                  setIsLoading(false);
+                  setIsLoggedIn(true);
+                } catch (error) {
+                  // TODO: invalid credential error handling
+                  setError('Error getting credentials');
+                  setIsLoading(false);
+                }
+              })();
+            }}
+          >
             <Form
               actions={
                 <Button
+                  formAction="submit"
                   variant="primary"
                   className="btn-custom-primary"
-                  onClick={() => void getCredentials()}
+                  loading={isLoading}
                 >
                   <span style={{ color: colorBackgroundHomeHeader }}>
                     Sign in
@@ -70,69 +70,17 @@ export function EdgeLoginPage({ children }: PropsWithChildren<EdgeLoginProps>) {
                 header={<Header variant="h2">Sign in to edge gateway</Header>}
               >
                 <SpaceBetween direction="vertical" size="l">
-                  <FormField
-                    label="Hostname or IP address"
-                    description="The hostname or IP adddress of the gateway device."
-                  >
-                    <Input
-                      ariaLabel="Enter hostname or IP address"
-                      onChange={({ detail }) => setIpAddress(detail.value)}
-                      value={ipAddress}
-                      placeholder="Enter hostname or IP address"
-                    />
-                  </FormField>
-                  <FormField
-                    label="Authentication type"
-                    description="You can authenticate to this gateway with your Operating System Authentication or Lightweight Directory Access Protocol (LDAP) credentials."
-                  >
-                    <Select
-                      ariaLabel="Select an authentication type"
-                      onChange={({ detail }) =>
-                        setAuthMechanism({
-                          label: detail.selectedOption.label
-                            ? detail.selectedOption.label
-                            : '',
-                          value: detail.selectedOption.value
-                            ? detail.selectedOption.value
-                            : '',
-                        })
-                      }
-                      selectedOption={authMechanism}
-                      options={[
-                        { label: 'Linux', value: 'linux' },
-                        { label: 'LDAP', value: 'ldap' },
-                      ]}
-                    />
-                  </FormField>
-                  <FormField
-                    label="Username"
-                    description="The user name of your operating system or LDAP."
-                  >
-                    <Input
-                      ariaLabel="Enter username"
-                      onChange={({ detail }) => setUsername(detail.value)}
-                      value={username}
-                      placeholder="Enter username"
-                    />
-                  </FormField>
-                  <FormField
-                    label="Password"
-                    description="The password of your operating system or LDAP user."
-                  >
-                    <Input
-                      ariaLabel="Enter password"
-                      onChange={({ detail }) => setPassword(detail.value)}
-                      value={password}
-                      type="password"
-                      placeholder="Enter password"
-                    />
-                  </FormField>
+                  <EdgeEndpointField control={control} />
+                  <EdgeMechanismField control={control} />
+                  <EdgeUsernameField control={control} />
+                  <EdgePasswordField control={control} />
                 </SpaceBetween>
               </Container>
             </Form>
           </form>
+          {!isProdEnv && <DevTool control={control} />}
         </Box>
-        <div></div>
+        <div />
       </ColumnLayout>
     );
   }

--- a/apps/client/src/routes/edge-login/hooks/use-edge-login-form.ts
+++ b/apps/client/src/routes/edge-login/hooks/use-edge-login-form.ts
@@ -1,0 +1,21 @@
+import { useForm } from 'react-hook-form';
+
+export type EdgeAuthMechanisms = 'linux' | 'ldap';
+
+export interface EdgeLoginFormValues {
+  edgeEndpoint: string;
+  username: string;
+  password: string;
+  authMechanism: EdgeAuthMechanisms;
+}
+
+export const DEFAULT_VALUES: EdgeLoginFormValues = {
+  edgeEndpoint: '',
+  username: '',
+  password: '',
+  authMechanism: 'linux',
+};
+
+export function useEdgeLoginForm() {
+  return useForm({ defaultValues: DEFAULT_VALUES });
+}


### PR DESCRIPTION
# Description

* Add using react form with validation for the edge login form 
* Added loading state to button during login call
* Switched from using a hook to the login call to just calling it directly. For an API call that is always tied to an action and should only happen once, I don't think tanstack has any benefts here, for example here just calling the `edgeLogin` service was easier. 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manually tested logging in to an edge gateway

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
