### PR TITLE
feat: edge client auth service

### DIFF
--- a/apps/client/src/auth/auth-service.interface.ts
+++ b/apps/client/src/auth/auth-service.interface.ts
@@ -11,6 +11,11 @@ export interface AuthService {
   getAwsCredentials(): Promise<AwsCredentialIdentity>;
 
   /**
+   * Sets the user's AWS Credentials.
+   */
+  setAwsCredentials(credentials: AwsCredentialIdentity): void;
+
+  /**
    * AWS Region to obtain the AWS Credentials from.
    */
   get awsRegion(): string;

--- a/apps/client/src/auth/cognito-auth-service.ts
+++ b/apps/client/src/auth/cognito-auth-service.ts
@@ -1,0 +1,53 @@
+import { Auth, Hub } from 'aws-amplify';
+import { AuthService } from './auth-service.interface';
+import { type AwsCredentialIdentity } from '@smithy/types';
+
+export class CognitoAuthService implements AuthService {
+  private credentials?: AwsCredentialIdentity;
+
+  setAwsCredentials(credentials: AwsCredentialIdentity) {
+    this.credentials = credentials;
+  }
+
+  getAwsCredentials() {
+    if (this.credentials != null) {
+      return Promise.resolve(this.credentials);
+    }
+
+    return Auth.currentCredentials();
+  }
+
+  get awsRegion() {
+    return Auth.configure().region ?? 'us-west-2';
+  }
+
+  async getToken() {
+    const session = await Auth.currentSession();
+    return session.getAccessToken().getJwtToken();
+  }
+
+  /**
+   * This function accepts a callback function to call when application is signed-in or already signed-in
+   * @param callback the callback function to call when application is signed-in
+   */
+  async onSignedIn(callback: () => unknown) {
+    /**
+     * Either Auth.currentAuthenticatedUser() or callback of Hub.listen('auth', xxx) is executed initially;
+     * Callback of Hub.listen('auth', xxx) is executed for every sign-in;
+     */
+    try {
+      // Check for initial authentication state
+      await Auth.currentAuthenticatedUser();
+      callback();
+    } catch (e) {
+      // NOOP; not yet authenticated;
+    }
+
+    // Listen for sign-in events
+    Hub.listen('auth', (capsule) => {
+      if (capsule.payload.event === 'signIn') {
+        callback();
+      }
+    });
+  }
+}

--- a/apps/client/src/auth/edge-auth-service.ts
+++ b/apps/client/src/auth/edge-auth-service.ts
@@ -1,0 +1,39 @@
+import { AuthService } from './auth-service.interface';
+import { type AwsCredentialIdentity } from '@smithy/types';
+
+export class EdgeAuthService implements AuthService {
+  private region = 'edge';
+  private credentials: AwsCredentialIdentity = {
+    accessKeyId: '',
+    secretAccessKey: '',
+  };
+
+  setAwsCredentials(credentials: AwsCredentialIdentity) {
+    this.credentials = credentials;
+  }
+
+  getAwsCredentials() {
+    return Promise.resolve(this.credentials);
+  }
+
+  get awsRegion() {
+    return this.region;
+  }
+
+  getToken() {
+    if (this.credentials.sessionToken) {
+      return Promise.resolve(this.credentials.sessionToken);
+    }
+
+    // TODO: Handle session token in edge mode
+    return Promise.resolve('');
+  }
+
+  /**
+   * This function accepts a callback function to call when application is signed-in or already signed-in
+   * @param callback the callback function to call when application is signed-in
+   */
+  onSignedIn(callback: () => unknown) {
+    callback();
+  }
+}

--- a/apps/client/src/helpers/authMode.ts
+++ b/apps/client/src/helpers/authMode.ts
@@ -1,0 +1,7 @@
+import { extractedMetaTags } from './meta-tags';
+
+export const getAuthMode = () => {
+  const tags = Array.from(document.getElementsByTagName('meta'));
+  const { authMode } = extractedMetaTags(tags);
+  return authMode;
+};

--- a/apps/client/src/index.tsx
+++ b/apps/client/src/index.tsx
@@ -10,7 +10,7 @@ import { RouterProvider } from 'react-router-dom';
 import { DEFAULT_LOCALE } from './constants';
 import { router } from './router';
 import { queryClient } from './data/query-client';
-import { setAuthMode, setServiceUrl } from './services';
+import { setServiceUrl } from './services';
 import metricHandler from './metrics/metric-handler';
 import { extractedMetaTags } from './helpers/meta-tags';
 import { registerServiceWorker } from './register-service-worker';
@@ -85,7 +85,6 @@ if (awsAccessKeyId !== '' && awsSecretAccessKey !== '') {
   });
 }
 
-setAuthMode(authMode);
 setServiceUrl('/api');
 
 const rootEl = document.getElementById('root');
@@ -95,16 +94,14 @@ if (authMode === 'edge') {
     // TODO: We need a way to login without <Authenticator> component that's heavily tied to Amplify/Cognito
     ReactDOM.createRoot(rootEl).render(
       <React.StrictMode>
-        <Authenticator>
-          <IntlProvider locale="en" defaultLocale={DEFAULT_LOCALE}>
-            <QueryClientProvider client={queryClient}>
-              <EdgeLoginPage>
-                <RouterProvider router={router} />
-                <ReactQueryDevtools initialIsOpen={false} />
-              </EdgeLoginPage>
-            </QueryClientProvider>
-          </IntlProvider>
-        </Authenticator>
+        <IntlProvider locale="en" defaultLocale={DEFAULT_LOCALE}>
+          <QueryClientProvider client={queryClient}>
+            <EdgeLoginPage>
+              <RouterProvider router={router} />
+              <ReactQueryDevtools initialIsOpen={false} />
+            </EdgeLoginPage>
+          </QueryClientProvider>
+        </IntlProvider>
       </React.StrictMode>,
     );
   }
@@ -128,5 +125,5 @@ if (authMode === 'edge') {
 registerServiceWorker();
 registerLogger(logMode);
 registerMetricsRecorder(metricsMode);
-void authService.onSignedIn(() => initializeAuthDependents(applicationName));
+authService.onSignedIn(() => initializeAuthDependents(applicationName));
 metricHandler.reportWebVitals();

--- a/apps/client/src/layout/components/top-navigation/top-navigation.tsx
+++ b/apps/client/src/layout/components/top-navigation/top-navigation.tsx
@@ -8,11 +8,12 @@ import { ROOT_HREF } from '~/constants';
 import { preventFullPageLoad } from '~/helpers/events';
 import { useApplication } from '~/hooks/application/use-application';
 
-export function TopNavigation() {
+import { getAuthMode } from '~/helpers/authMode';
+
+function EdgeNavigation() {
   const [isSettingsModalVisible, setIsSettingsModalVisible] = useState(false);
   const { navigate } = useApplication();
   const intl = useIntl();
-  const { user, signOut } = useAuthenticator();
 
   function openSettings() {
     setIsSettingsModalVisible(true);
@@ -22,6 +23,108 @@ export function TopNavigation() {
     setIsSettingsModalVisible(false);
   }
 
+  return (
+    <div id="h" style={{ position: 'sticky', top: 0, zIndex: 1002 }}>
+      <_TopNavigation
+        identity={{
+          href: ROOT_HREF,
+          title: intl.formatMessage({
+            defaultMessage: 'IoT dashboard application',
+            description: 'top navigation home link',
+          }),
+          onFollow: (event) => {
+            preventFullPageLoad(event);
+            navigate(ROOT_HREF);
+          },
+        }}
+        utilities={[
+          {
+            type: 'button',
+            iconName: 'settings',
+            ariaLabel: intl.formatMessage({
+              defaultMessage: 'Settings',
+              description: 'settings button aria label',
+            }),
+            text: intl.formatMessage({
+              defaultMessage: 'Settings',
+              description: 'top navigation settings button',
+            }),
+            variant: 'link',
+            onClick: openSettings,
+          },
+          {
+            type: 'menu-dropdown',
+            text: '', // TODO: add edge user details
+            description: '',
+            iconName: 'user-profile',
+            onItemClick: (event) => {
+              if (event.detail.id === 'signout') {
+                // TODO: call signout for edge mode
+              }
+            },
+            items: [
+              {
+                id: 'documentation',
+                text: intl.formatMessage({
+                  defaultMessage: 'Documentation',
+                  description: 'top nav documentation link',
+                }),
+                href: 'https://github.com/awslabs/iot-application',
+                external: true,
+              },
+              {
+                id: 'feedback',
+                text: intl.formatMessage({
+                  defaultMessage: 'Feedback',
+                  description: 'top nav feedback link',
+                }),
+                href: 'https://github.com/awslabs/iot-application/issues',
+                external: true,
+              },
+              {
+                id: 'signout',
+                text: intl.formatMessage({
+                  defaultMessage: 'Signout',
+                  description: 'top nav signout button',
+                }),
+              },
+            ],
+          },
+        ]}
+        i18nStrings={{
+          overflowMenuTitleText: intl.formatMessage({
+            defaultMessage: 'All',
+            description: 'top nav overflow menu title',
+          }),
+          overflowMenuTriggerText: intl.formatMessage({
+            defaultMessage: 'More',
+            description: 'top nav overflow menu triggle',
+          }),
+        }}
+      />
+
+      <SettingsModal
+        isVisible={isSettingsModalVisible}
+        onClose={closeSettings}
+        key={isSettingsModalVisible.toString()}
+      />
+    </div>
+  );
+}
+
+function CognitoNavigation() {
+  const [isSettingsModalVisible, setIsSettingsModalVisible] = useState(false);
+  const { navigate } = useApplication();
+  const intl = useIntl();
+
+  function openSettings() {
+    setIsSettingsModalVisible(true);
+  }
+
+  function closeSettings() {
+    setIsSettingsModalVisible(false);
+  }
+  const { user, signOut } = useAuthenticator();
   return (
     <div id="h" style={{ position: 'sticky', top: 0, zIndex: 1002 }}>
       <_TopNavigation
@@ -110,3 +213,13 @@ export function TopNavigation() {
     </div>
   );
 }
+
+let Navigation;
+
+if (getAuthMode() === 'edge') {
+  Navigation = EdgeNavigation;
+} else {
+  Navigation = CognitoNavigation;
+}
+
+export const TopNavigation = Navigation;

--- a/apps/client/src/logging/cloud-watch-logger.spec.ts
+++ b/apps/client/src/logging/cloud-watch-logger.spec.ts
@@ -21,6 +21,7 @@ describe('CloudWatchLogger', () => {
     awsRegion: 'us-west-2',
     getToken: vi.fn(),
     onSignedIn: vi.fn(),
+    setAwsCredentials: vi.fn(),
   };
 
   beforeEach(() => {

--- a/apps/client/src/metrics/cloud-watch-metrics-recorder.spec.ts
+++ b/apps/client/src/metrics/cloud-watch-metrics-recorder.spec.ts
@@ -21,6 +21,7 @@ describe('CloudWatchMetricsRecorder', () => {
     awsRegion: 'us-west-2',
     getToken: vi.fn(),
     onSignedIn: vi.fn(),
+    setAwsCredentials: vi.fn(),
   };
 
   beforeEach(() => {

--- a/apps/client/src/routes/dashboards/dashboard/dashboard-route.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-route.tsx
@@ -12,6 +12,8 @@ import invariant from 'tiny-invariant';
 import { Dashboard } from '~/services';
 import { Maybe } from '~/types';
 
+import { getAuthMode } from '~/helpers/authMode';
+
 export const dashboardRoute = {
   path: DASHBOARD_PATH,
   element: (
@@ -21,11 +23,16 @@ export const dashboardRoute = {
   ),
   loader: async ({ params }) => {
     invariant(params.dashboardId, 'Expected dashboardId is to be defined');
-    /**
-     * The loader is called before the element is rendered. This means we need
-     * to wait for authentication state before we can fetch the dashboard.
-     */
-    await Auth.currentAuthenticatedUser();
+
+    // Wait for Cognito user, not needed in edge mode
+    if (getAuthMode() !== 'edge') {
+      /**
+       * The loader is called before the element is rendered. This means we need
+       * to wait for authentication state before we can fetch the dashboard.
+       */
+      await Auth.currentAuthenticatedUser();
+    }
+
     return queryClient.fetchQuery(createDashboardQuery(params.dashboardId));
   },
   handle: {

--- a/apps/client/src/services/index.ts
+++ b/apps/client/src/services/index.ts
@@ -29,14 +29,10 @@ import type {
 import { DashboardMigration, DashboardMigrationStatus } from './types';
 import { EdgeLogin } from './types';
 
-let authMode = 'cognito';
+import { getAuthMode } from '~/helpers/authMode';
 
-export function setAuthMode(mode: string) {
-  authMode = mode;
-}
-
-function isEdgeMode() {
-  return authMode === 'edge';
+export function isEdgeMode() {
+  return getAuthMode() === 'edge';
 }
 
 OpenAPI.TOKEN = () => authService.getToken();

--- a/apps/core/.env
+++ b/apps/core/.env
@@ -13,5 +13,6 @@ DATABASE_LAUNCH_LOCAL=true
 DATABASE_PORT=8000
 DATABASE_TABLE_NAME=ApiResourceTable
 NODE_ENV=development
+AUTH_MODE=cognito
 # WebPack Server, Local Cognito and DDB endpoints, and AWS endpoints
 SERVICE_ENDPOINTS='ws://localhost:3001 http://localhost:9229 http://localhost:8000 https://*.amazonaws.com'


### PR DESCRIPTION
# Description

* Adding the edge client auth service
   * Conditionally set `authService` to be the edge implementation or the cognito implementation 
   * Add some more conditionals like for the top navigation that previously depends on a cognito user
* I was thinking about how to make `authMode` globally available
   * The solution I used in this PR was to get authMode from the meta tag when needed instead of storing it in services. This seemed easier since we could reference it throughout the client without having to create additional global state. I'm open to any other solutions though. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Locally, set `AUTH_MODE` to cognito and edge and verified both work. Still need to test both when deployed in cloud.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
