### PR TITLE
feat: hide migration in edge mode

### DIFF
--- a/apps/client/src/auth/edge-auth-service.ts
+++ b/apps/client/src/auth/edge-auth-service.ts
@@ -34,6 +34,11 @@ export class EdgeAuthService implements AuthService {
    * @param callback the callback function to call when application is signed-in
    */
   onSignedIn(callback: () => unknown) {
-    callback();
+    if (
+      this.credentials.accessKeyId !== '' &&
+      this.credentials.secretAccessKey !== ''
+    ) {
+      callback();
+    }
   }
 }

--- a/apps/client/src/helpers/authMode.ts
+++ b/apps/client/src/helpers/authMode.ts
@@ -1,7 +1,8 @@
 import { extractedMetaTags } from './meta-tags';
+import once from 'lodash/once';
 
-export const getAuthMode = () => {
+export const getAuthMode = once(() => {
   const tags = Array.from(document.getElementsByTagName('meta'));
   const { authMode } = extractedMetaTags(tags);
   return authMode;
-};
+});

--- a/apps/client/src/index.tsx
+++ b/apps/client/src/index.tsx
@@ -91,7 +91,6 @@ const rootEl = document.getElementById('root');
 
 if (authMode === 'edge') {
   if (rootEl != null) {
-    // TODO: We need a way to login without <Authenticator> component that's heavily tied to Amplify/Cognito
     ReactDOM.createRoot(rootEl).render(
       <React.StrictMode>
         <IntlProvider locale="en" defaultLocale={DEFAULT_LOCALE}>

--- a/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboards-index/dashboards-index-page.tsx
@@ -38,6 +38,7 @@ import { setDashboardEditMode } from '~/store/viewMode';
 import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
 
 import './styles.css';
+import { getAuthMode } from '~/helpers/authMode';
 
 const DateFormatOptions: FormatDateOptions = {
   year: 'numeric',
@@ -175,9 +176,13 @@ export function DashboardsIndexPage() {
       <Box>
         <GettingStarted />
       </Box>
-      <Box padding={{ top: 'l' }}>
-        <Migration onMigrationComplete={() => void dashboardsQuery.refetch()} />
-      </Box>
+      {getAuthMode() !== 'edge' && (
+        <Box padding={{ top: 'l' }}>
+          <Migration
+            onMigrationComplete={() => void dashboardsQuery.refetch()}
+          />
+        </Box>
+      )}
       <Box padding={{ top: 'l' }}>
         <Table
           {...collectionProps}


### PR DESCRIPTION
# Description

* Hiding the migration feature in edge mode since the credentials won't be able to make the necessary SiteWise Monitor calls
* Added some small follow ups - call onSignedIn callback only if credentials were succesfully set, use lodash `once` for getting auth mode, remove outdated comment

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] set `AUTH_MODE` env variable to both cognito and edge and validated the different behaviours.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
