### PR TITLE
fix: preserve view mode on save

### DIFF
--- a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
+++ b/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx
@@ -4,7 +4,7 @@ import {
 } from '@iot-app-kit/dashboard';
 import { useParams } from 'react-router-dom';
 import invariant from 'tiny-invariant';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 
 import { DashboardLoadingState } from './components/dashboard-loading-state';
@@ -16,7 +16,7 @@ import type { DashboardDefinition } from '~/services';
 import { useViewport } from '~/hooks/dashboard/use-viewport';
 import { useEmitNotification } from '~/hooks/notifications/use-emit-notification';
 import { useDisplaySettings } from '~/hooks/dashboard/use-displaySettings';
-import { getDashboardEditMode } from '~/store/viewMode';
+import { getDashboardEditMode, setDashboardEditMode } from '~/store/viewMode';
 import { GenericErrorNotification } from '~/structures/notifications/generic-error-notification';
 
 import './styles.css';
@@ -25,6 +25,7 @@ import { authService } from '~/auth/auth-service';
 export function DashboardPage() {
   const params = useParams<{ dashboardId: string }>();
   const editMode = useAtomValue(getDashboardEditMode);
+  const emitEditMode = useSetAtom(setDashboardEditMode);
   const emitNotification = useEmitNotification();
 
   invariant(
@@ -81,7 +82,11 @@ export function DashboardPage() {
       name={dashboardQuery.data?.name}
       onSave={(
         config: DashboardDefinition & Omit<DashboardConfiguration, 'widgets'>,
+        viewModeOnSave?: 'preview' | 'edit',
       ) => {
+        if ((viewModeOnSave === 'edit') !== editMode) {
+          emitEditMode(viewModeOnSave === 'edit');
+        }
         invariant(params.dashboardId, 'Expected dashboard ID to be defined');
         invariant(dashboardQuery.data, 'Expected dashboard to be loaded');
         void updateDashboardMutation.mutateAsync({


### PR DESCRIPTION
# Description

Keep the view mode when user clicks save instead of always going back to edit mode

https://github.com/awslabs/iot-application/assets/28601414/6c349e8c-3251-4bb5-b4ba-92424290f072


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
