### PR TITLE
feat: add 401 exception handling for edge

### DIFF
--- a/apps/client/src/routes/edge-login/edge-login-page.tsx
+++ b/apps/client/src/routes/edge-login/edge-login-page.tsx
@@ -16,6 +16,12 @@ import { EdgeUsernameField } from './components/edge-username-field';
 import { EdgeMechanismField } from './components/edge-mechanism-field';
 import { EdgePasswordField } from './components/edge-password-field';
 import { edgeLogin } from '~/services';
+import { ApiError } from '~/services/generated/core/ApiError';
+
+// Adding type since ApiError types body as any
+interface ApiErrorBody {
+  message: string;
+}
 
 export function EdgeLoginPage({ children }: PropsWithChildren) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -44,8 +50,12 @@ export function EdgeLoginPage({ children }: PropsWithChildren) {
                   setIsLoading(false);
                   setIsLoggedIn(true);
                 } catch (error) {
-                  // TODO: invalid credential error handling
-                  setError('Error getting credentials');
+                  if (error instanceof ApiError) {
+                    const errorBody = error.body as ApiErrorBody;
+                    setError(errorBody.message);
+                  } else {
+                    setError('Error logging in.');
+                  }
                   setIsLoading(false);
                 }
               })();


### PR DESCRIPTION
# Description

* Handle 401 response from edge gateway and display "Invalid username or password" message to differentiate invalid linux/ldap credentials from other api errors

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested logging in with invalid and valid passwords and matching messages

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
