### PR TITLE
chore: set dependabot to target rc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: weekly
+    target-branch: rc
     open-pull-requests-limit: 10
     groups:
       aws-sdk:
@@ -20,3 +21,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    target-branch: rc


### PR DESCRIPTION
## Overview
This change sets Dependabot to target `rc` instead of `main` to reduce the risk of merge conflicts during release process.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
