### PR TITLE
chore: increase timeout limit for playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   playwright:
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Description

Increasing playwright tests timeout setting from 15 to 20 minutes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
