### PR TITLE
fix: add bootstrap command back to deploy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "npx turbo run clean && rimraf .turbo && rimraf --glob *.tsbuildinfo",
     "clean:full": "npx turbo run clean:full && rimraf .turbo && rimraf --glob *.tsbuildinfo && rimraf node_modules",
     "dev": "turbo run dev",
-    "deploy": "yarn install && yarn clean && node deployCdk.js",
+    "deploy": "yarn install && yarn clean && yarn workspace cdk bootstrap && node deployCdk.js",
     "gen:types": "openapi -i ${npm_package_config_docs} -o ${npm_package_config_genpath} ${npm_package_config_genconfig} && yarn format:gen:types",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:gen:types": "prettier --write \"${npm_package_config_genpath}/**/*.ts\"",


### PR DESCRIPTION
# Description

* When [adding deployment choice feature](https://github.com/awslabs/iot-application/commit/bf4a8df9593dd6d43cc6245902d7aed78acab6ec#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) I accidentally removed the bootstrap command. This change adds it back. This makes it so the cdk bootstrap command is ran automatically for deployment; the step is skipped if bootstrapping has already been done.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Ran `yarn deploy` and validated bootstrap is ran and bootstraps environment if not already done

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
