### PR TITLE
 fix: viewport should default to 5 mins option

### DIFF
--- a/apps/client/src/hooks/dashboard/use-viewport.ts
+++ b/apps/client/src/hooks/dashboard/use-viewport.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from 'react-use';
 import type { Viewport } from '@iot-app-kit/core';
 
-const DEFAULT_VIEWPORT: Viewport = { duration: '5 minutes' };
+const DEFAULT_VIEWPORT: Viewport = { duration: '5 minute' };
 export const useViewport = (dashboardId: string) => {
   return useLocalStorage<Viewport>(
     `dashboard-${dashboardId}-viewport`,


### PR DESCRIPTION
# Description

We noticed that certain playwright tests were failing because the viewport default was a custom value of last 300 seconds instead of the last 5m option. This was due to the conversion from the viewport duration object value being inconsistent. A value of "5 minutes" resulted in the date range picker setting it to be last 300 seconds where as "5 minute" gave us the wanted behavior. This comes from the code in app-kit that sets the value of the TImeSelection component based on the passed in viewport. 

https://github.com/awslabs/iot-application/assets/145582655/b5282310-25e0-4160-8bba-1b044cbea0d8


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
