### PR TITLE
fix(Dockerfile): node mem option typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=linux/amd64 node:18-alpine as builder
+FROM --platform=linux/amd64 node:18-alpine AS builder
 
 WORKDIR /usr/src/app-build
 
 # Configure Node memory allocation
-ENV NODE_OPTIONS=--max_old_space_size=4096
+ENV NODE_OPTIONS=--max-old-space-size=4096
 
 # Copy package.json files
 COPY ./package.json ./package.json
@@ -34,7 +34,7 @@ RUN yarn workspace core build
 RUN yarn workspace core install --frozen-lockfile --production
 
 
-FROM --platform=linux/amd64  node:18-alpine as packager
+FROM --platform=linux/amd64  node:18-alpine AS packager
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
# Description

There is a typo in the node mem option:
Current: `--max_old_space_size`
Corrected: `--max-old-space-size`

Notice the underscore (`_`) and dash (`-`).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployment GH WF

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
