### PR TITLE
fix: cloudformation deployment's instance role reference

### DIFF
--- a/app-deployment-cfn.template.yaml
+++ b/app-deployment-cfn.template.yaml
@@ -75,7 +75,6 @@ Resources:
             yarn workspace cdk bootstrap
             yarn workspace cdk deploy:no-review:${AuthenticationMode} -c stackName=${ApplicationStackName}
             /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource DeploymentEC2Instance --region ${AWS::Region}
-            aws cloudformation delete-stack --stack-name ${AWS::StackId} --region ${AWS::Region}
   DeploymentEC2InstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -91,4 +90,4 @@ Resources:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Roles:
-        - Ec2InstanceRole
+        - !Ref DeploymentEC2InstanceRole

--- a/deploymentguide/README.md
+++ b/deploymentguide/README.md
@@ -7,8 +7,9 @@ This is the simplest method to deploy the application. It deploys the applicatio
 1. Download the provided CloudFormation template from the [download link](../app-deployment-cfn.template.yaml)
 1. Deploy the provided CloudFormation template to your AWS account using CloudFormation console or AWS CLI
 1. The deployment process could take up to 30 minutes
-1. After a successfull deployment, a CloudFormation stack is created for the application and this CloudFormation stack will delete iteself
 1. To start using the application, please refer to [user guide](../userguide/README.md)
+1. After a successfull deployment, delete the CloudFormation stack created in step 2  
+   The CloudFormation stack created in step 2 is necessary for deployment purpose only and deleting the stack does not affect the application
 
 ## Deploying to AWS Cloud with CDK
 


### PR DESCRIPTION
# Description

Previous the `DeploymentEC2InstanceProfile` has a wrong reference of the role;
fixed it `Ec2InstanceRole` -> `DeploymentEC2InstanceRole`

Fixes # (issue)
#2163

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manual deployed and verified

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
